### PR TITLE
Change hassio_role from admin to manager

### DIFF
--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -8,7 +8,7 @@ description: >
 url: "https://github.com/brenner-tobias/addon-cloudflared/"
 init: false
 hassio_api: true
-hassio_role: admin
+hassio_role: manager
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
Improving add-on security possible by changing hassio_role from admin to manager

# Proposed Changes

manager role should be sufficient for getting nginxproxymanager add-on information

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
