### PR TITLE
✨ Add option to use quick tunnels

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -17,6 +17,23 @@ Please make sure to be compliant with the
 add-on. Especially [section 2.8][cloudflare-sssa-28] could be breached when
 mainly streaming videos or other Non-HTML content.
 
+## Quick Tunnel for Testing
+
+You can get started with zero setup by using
+[Cloudflare Quick Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/run-tunnel/trycloudflare).
+Set `quick_tunnel` to `true` , all other configuration will be ignored. After
+starting the addon check the logs for your unique randomly generated
+`trycloudflare.com` URL.
+
+Quick Tunnel add-on configuration:
+
+```yaml
+quick_tunnel: true
+external_hostname: ''
+tunnel_name: ''
+additional_hosts: []
+```
+
 ## Installation
 
 The installation of this add-on is pretty straightforward but requires some prerequisites

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -27,5 +27,6 @@ schema:
       service: str
       disableChunkedEncoding: bool?
   nginxproxymanager: bool?
+  quick_tunnel: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   reset_cloudflared_files: bool?

--- a/cloudflared/rootfs/etc/cont-init.d/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/cont-init.d/cloudflared-config.sh
@@ -239,6 +239,12 @@ tunnel_uuid=""
 main() {
     bashio::log.trace "${FUNCNAME[0]}"
 
+    # Quick Tunnel with 0 config
+    if bashio::config.true 'quick_tunnel'; then
+        bashio::log.info "Using Cloudflare Quick Tunnels"
+        bashio::exit.ok
+    fi
+
     external_hostname="$(bashio::config 'external_hostname')"
     tunnel_name="$(bashio::config 'tunnel_name')"
 

--- a/cloudflared/rootfs/etc/services.d/cloudflared/run
+++ b/cloudflared/rootfs/etc/services.d/cloudflared/run
@@ -3,10 +3,16 @@
 # Home Assistant Add-on: Cloudflared
 # Connects and runs the Cloudfalred tunnel for HomeAssistant
 # ==============================================================================
-certificate="/data/cert.pem"
-config="/data/config.json"
-tunnel_name="$(bashio::config 'tunnel_name')"
 
-bashio::log.info "Connecting Cloudflared Tunnel..."
+if bashio::config.true 'quick_tunnel'; then
+    bashio::log.info "Connecting Cloudflared Quick Tunnel..."
+    exec cloudflared tunnel --url "http://homeassistant:$(bashio::core.port)"
+else
+    certificate="/data/cert.pem"
+    config="/data/config.json"
+    tunnel_name="$(bashio::config 'tunnel_name')"
 
-exec cloudflared --origincert=${certificate} --no-autoupdate tunnel --config=${config} run "${tunnel_name}"
+    bashio::log.info "Connecting Cloudflared Tunnel..."
+
+    exec cloudflared --origincert=${certificate} --no-autoupdate tunnel --config=${config} run "${tunnel_name}"
+fi


### PR DESCRIPTION
# Proposed Changes

This adds a 0 config/setup option for users to create a tunnel. Not recommended for production, but provides and easy and approachable way to test Cloudflare Tunnels.

```bash
2022-01-20T09:56:33Z INF Thank you for trying Cloudflare Tunnel. Doing so, without a Cloudflare account, is a quick way to experiment and try it out. However, be aware that these account-less Tunnels have no uptime guarantee. If you intend to use Tunnels in production you should use a pre-created named tunnel by following: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps
2022-01-20T09:56:33Z INF Requesting new quick Tunnel on trycloudflare.com...
2022-01-20T09:56:36Z INF +--------------------------------------------------------------------------------------------+
2022-01-20T09:56:36Z INF |  Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):  |
2022-01-20T09:56:36Z INF |  https://disciplinary-tennis-breaking-under.trycloudflare.com                              |
2022-01-20T09:56:36Z INF +--------------------------------------------------------------------------------------------+
```
