### PR TITLE
Add originRequest support for disableChunkedEncoding flag

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -70,6 +70,7 @@ additional_hosts:
     service: "https://192.168.1.2:5001"
   - hostname: "website.example.com"
     service: "http://192.168.1.3:8080"
+    disableChunkedEncoding: true
 nginxproxymanager: true
 log_level: "debug"
 ```
@@ -101,6 +102,11 @@ other systems like a diskstation, router or anything else.
 Like with the `external_hostname` of HomeAssistant, DNS entries at will be
 automatically created at Cloudflare.
 
+Add the (optional) `disableChunkedEncoding` option to a hostname, to disable
+chunked transfer encoding. This is useful if you are running a WSGI server,
+like Proxmox for example. Visit [Cloudflare Docs][disablechunkedencoding] for
+further information. 
+
 Please find below an examplary entry for two additional hosts:
 
 ```yaml
@@ -111,6 +117,7 @@ additional_hosts:
     service: "https://192.168.1.2:5001"
   - hostname: "website.example.com"
     service: "http://192.168.1.3:8080"
+    disableChunkedEncoding: true
 ```
 
 **Note**: _If you delete a hostname from the list, it will not be served
@@ -226,3 +233,4 @@ SOFTWARE.
 [freenom]: https://freenom.com
 [nginxproxymanager]: https://github.com/hassio-addons/addon-nginx-proxy-manager
 [tobias]: https://github.com/brenner-tobias
+[disablechunkedencoding]: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file/ingress#disablechunkedencoding

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -105,7 +105,7 @@ automatically created at Cloudflare.
 Add the (optional) `disableChunkedEncoding` option to a hostname, to disable
 chunked transfer encoding. This is useful if you are running a WSGI server,
 like Proxmox for example. Visit [Cloudflare Docs][disablechunkedencoding] for
-further information. 
+further information.
 
 Please find below an examplary entry for two additional hosts:
 

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -25,6 +25,7 @@ schema:
   additional_hosts:
     - hostname: str
       service: str
+      disableChunkedEncoding: bool?
   nginxproxymanager: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   reset_cloudflared_files: bool?

--- a/cloudflared/rootfs/etc/cont-init.d/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/cont-init.d/cloudflared-config.sh
@@ -200,7 +200,7 @@ createConfig() {
     fi
 
     # Deactivate TLS verification for all services
-    config=$(bashio::jq "${config}" ".ingress[] | .originRequest += {\"noTLSVerify\": true}")
+    config=$(bashio::jq "${config}" ".ingress[].originRequest += {\"noTLSVerify\": true}")
 
     # Write content of config variable to config file for cloudflared
     bashio::jq "${config}" "." > /data/config.json


### PR DESCRIPTION
# Proposed Changes

The disableChunkedEncoding flag for origin is useful for host services using WSGI servers. 
For example Proxmox server isn't working with cloudflare tunnel without related service settings. 

See https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file/ingress#notlsverify for further information. 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
