### PR TITLE
Change HA hostname to IP within Docker network

### DIFF
--- a/cloudflared/rootfs/etc/cont-init.d/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/cont-init.d/cloudflared-config.sh
@@ -184,7 +184,7 @@ createConfig() {
     config=$(bashio::jq "${config}" ".\"credentials-file\" += \"/data/tunnel.json\"")
 
     # Add Service for Home-Assistant
-    config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"http://homeassistant:$(bashio::core.port)\"}]")
+    config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"http://172.30.32.1:$(bashio::core.port)\"}]")
 
     # Check for configured additional hosts and add them if existing
     if bashio::config.has_value 'additional_hosts' ; then


### PR DESCRIPTION
# Proposed Changes

> Switch from usage of hostname "homeassistant" to IP of internal Docker network 172.30.32.1 in the tunnel configuration for the connection to Home Assitante

## Related Issues

> Closes #38
