### PR TITLE
Bugfix reading tunnel name from tunnel.json

### DIFF
--- a/cloudflared/rootfs/etc/cont-init.d/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/cont-init.d/10-cloudflared-config.sh
@@ -141,7 +141,8 @@ hasTunnel() {
     # Check if tunnel name in file matches config value
     bashio::log.info "Checking if existing tunnel matches name given in config"
     local tunnel_name_from_file
-    tunnel_name_from_file="$(bashio::jq "${data_path}/tunnel.json" .TunnelName)"
+    tunnel_name_from_file=$(cloudflared --origincert="${data_path}/cert.pem" tunnel \
+        list --output="json" --id="${tunnel_uuid}" | jq -er '.[].name')
     bashio::log.debug "Tunnnel name read from file: $tunnel_name_from_file"
     if [[ $tunnel_name != "$tunnel_name_from_file" ]]; then
         bashio::log.warning "Tunnel name in file does not match config, removing tunnel file"

--- a/cloudflared/rootfs/etc/cont-init.d/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/cont-init.d/10-cloudflared-config.sh
@@ -143,13 +143,13 @@ hasTunnel() {
     local existing_tunnel_name
     existing_tunnel_name=$(cloudflared --origincert="${data_path}/cert.pem" tunnel \
         list --output="json" --id="${tunnel_uuid}" | jq -er '.[].name')
-    bashio::log.debug "Tunnnel name read from file: $existing_tunnel_name"
+    bashio::log.debug "Existing Cloudflare tunnnel name: $existing_tunnel_name"
     if [[ $tunnel_name != "$existing_tunnel_name" ]]; then
-        bashio::log.warning "Tunnel name in file does not match config, removing tunnel file"
+        bashio::log.warning "Existing Cloudflare tunnel name does not match config, removing tunnel file"
         rm -f "${data_path}/tunnel.json"  || bashio::exit.nok "Failed to remove tunnel file"
         return "${__BASHIO_EXIT_NOK}"
     fi
-    bashio::log.info "Tunnnel name read from file matches config, proceeding with existing tunnel file"
+    bashio::log.info "Existing Cloudflare tunnnel name matches config, proceeding with existing tunnel file"
 
     return "${__BASHIO_EXIT_OK}"
 }

--- a/cloudflared/rootfs/etc/cont-init.d/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/cont-init.d/10-cloudflared-config.sh
@@ -138,13 +138,13 @@ hasTunnel() {
 
     bashio::log.info "Existing tunnel with ID ${tunnel_uuid} found"
 
-    # Check if tunnel name in file matches config value
+    # Get tunnel name from Cloudflare API by tunnel id and chek if it matches config value
     bashio::log.info "Checking if existing tunnel matches name given in config"
-    local tunnel_name_from_file
-    tunnel_name_from_file=$(cloudflared --origincert="${data_path}/cert.pem" tunnel \
+    local existing_tunnel_name
+    existing_tunnel_name=$(cloudflared --origincert="${data_path}/cert.pem" tunnel \
         list --output="json" --id="${tunnel_uuid}" | jq -er '.[].name')
-    bashio::log.debug "Tunnnel name read from file: $tunnel_name_from_file"
-    if [[ $tunnel_name != "$tunnel_name_from_file" ]]; then
+    bashio::log.debug "Tunnnel name read from file: $existing_tunnel_name"
+    if [[ $tunnel_name != "$existing_tunnel_name" ]]; then
         bashio::log.warning "Tunnel name in file does not match config, removing tunnel file"
         rm -f "${data_path}/tunnel.json"  || bashio::exit.nok "Failed to remove tunnel file"
         return "${__BASHIO_EXIT_NOK}"


### PR DESCRIPTION
# Proposed Changes

Upstream logic changed when running `cloudflared tunnel create`.
`json.conf` no longer contains the `TunnelName` key.

Adapting add-on logic to gather tunnel name using Cloudflare API and tunnel id. 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
