### PR TITLE
Remove Manager API calls

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -293,10 +293,10 @@ From the above documentation:
 ### Option: `warp_routes`
 
 This option controls which routes will be added to your tunnel.
-The default setting (no `warp_routes` configured in add-on configuration) will
-route all connected networks through your tunnel.
+This option is mandatory if `warp_enable` is set to `true.
 
-You can override this by setting specifing networks (IP/CIDR) in `warp_routes`.
+See the example below on how to specifie networks (IP/CIDR) in
+`warp_routes`.
 
 ```yaml
 warp_routes:

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -8,7 +8,7 @@ url: "https://github.com/brenner-tobias/addon-cloudflared/"
 codenotary: dev@brenner.tech
 init: false
 hassio_api: true
-hassio_role: manager
+hassio_role: homeassistant
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
# Proposed Changes

- As discussed in #71
- Remove manager supervisor API calls
- Refactor Warp route logic (I guess we should mark this one as breaking change even if it does not really break something. Just makes it necessary to add warp_routes option --> add-on start will fail if option is missing)
- Documentation changes related to Warp updates 

## Related Issues

> closes #71 
