### PR TITLE
Disable apparmor for cloudflared

### DIFF
--- a/cloudflared/apparmor.txt
+++ b/cloudflared/apparmor.txt
@@ -31,7 +31,7 @@ profile cloudflared flags=(attach_disconnected,mediate_deleted) {
   /data/** rw,
 
   # Start new profile for cloudflared service
-  /usr/bin/cloudflared cx -> cloudflared,
+  #/usr/bin/cloudflared cx -> cloudflared,
 
   profile cloudflared flags=(attach_disconnected,mediate_deleted) {
     #include <abstractions/base>


### PR DESCRIPTION
# Proposed Changes

in reference to #106 

@brenner-tobias you are right, it isn't working for me neither. I guess there is something necessary missing inside the Apparmor profile for cloudflared. I disabled the apparmor for cloudflared and everything is working fine now, I haven't got the time atm to take a look at how apparmor works. Do you have the time or shall we disable it for now? 

Merging this PR will disable PR for cloudflare while keeping the custom apparmor profile. 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
