### PR TITLE
Log error message if tunnel name doesn't fit 

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -163,9 +163,14 @@ hasTunnel() {
         list --output="json" --id="${tunnel_uuid}" | jq -er '.[].name')
     bashio::log.debug "Existing Cloudflare tunnnel name: $existing_tunnel_name"
     if [[ $tunnel_name != "$existing_tunnel_name" ]]; then
-        bashio::log.warning "Existing Cloudflare tunnel name does not match config, removing tunnel file"
-        rm -f "${data_path}/tunnel.json"  || bashio::exit.nok "Failed to remove tunnel file"
-        return "${__BASHIO_EXIT_NOK}"
+        bashio::log.error "Existing Cloudflare tunnel name does not match add-on config."
+        bashio::log.error "---------------------------------------"
+        bashio::log.error "Add-on Configuration tunnel name: ${tunnel_name}"
+        bashio::log.error "Tunnel credentials file tunnel name: ${existing_tunnel_name}"
+        bashio::log.error "---------------------------------------"
+        bashio::log.error "Align add-on configuration to match existing tunnel credential file"
+        bashio::log.error "or reset the add-on. Take a look at the documentation on how to reset the add-on"
+        bashio::exit.nok
     fi
     bashio::log.info "Existing Cloudflare tunnnel name matches config, proceeding with existing tunnel file"
 


### PR DESCRIPTION
# Proposed Changes

#99 - Tunnel with name already exists

The error is occurring more frequently according to the HA community forum.
I can still imagine that the API call below (line 162) is leading to the problem and the current coding is overriding the actual problem by deleting the tunnel file. I would like to bypass the automated deletion of the file via an error message to make the error (if I'm right) visible. 

https://github.com/brenner-tobias/addon-cloudflared/blob/ae091e84705e34e5647b5258648eec9e278ff3cf/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh#L160-L169

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
