### PR TITLE
Healthcheck for HA cloudflare tunnel if connection is dropped

### DIFF
--- a/cloudflared/rootfs/build.sh
+++ b/cloudflared/rootfs/build.sh
@@ -40,4 +40,4 @@ chmod +x /usr/bin/cloudflared
 
 # Add needed packages
 apk add --no-cache \
-    yq=4.25.1-r2
+    yq=4.25.1-r3

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
@@ -14,12 +14,12 @@ if bashio::config.true 'quick_tunnel'; then
     fi
     bashio::log.info "Connecting Cloudflared Quick Tunnel..."
     exec cloudflared --no-autoupdate \
-    tunnel --loglevel="${CLOUDFLARED_LOG}" --url "${ha_service_protocol}://homeassistant:$(bashio::core.port)"
+    tunnel --metrics="localhost:36500" --loglevel="${CLOUDFLARED_LOG}" --url "${ha_service_protocol}://homeassistant:$(bashio::core.port)"
 
 elif bashio::config.has_value 'tunnel_token' ; then
     tunnel_token=$(bashio::config 'tunnel_token')
     exec cloudflared --no-autoupdate \
-            tunnel --loglevel="${CLOUDFLARED_LOG}" run --token="${tunnel_token}"
+            tunnel --metrics="localhost:36500" --loglevel="${CLOUDFLARED_LOG}" run --token="${tunnel_token}"
 
 else
     data_path="/data"
@@ -39,5 +39,5 @@ else
     bashio::log.debug "using ${config} config file"
     
     exec cloudflared --origincert=${certificate} --no-autoupdate \
-        tunnel --config=${config} --loglevel="${CLOUDFLARED_LOG}" run "${tunnel_name}"
+        tunnel --config=${config} --metrics="localhost:36500" --loglevel="${CLOUDFLARED_LOG}" run "${tunnel_name}"
 fi

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/finish
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/finish
@@ -1,0 +1,11 @@
+#!/command/with-contenv bashio
+# ==============================================================================
+# Home Assistant Add-on: Cloudflared
+# Take down the S6 supervision tree when healthcheck fails
+# ==============================================================================
+if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
+  bashio::log.warning "healthcheck crashed, halting add-on"
+  /run/s6/basedir/bin/halt
+fi
+
+bashio::log.info "healthcheck stoped, restarting..."

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
@@ -1,0 +1,43 @@
+#!/command/with-contenv bashio
+# ==============================================================================
+# Home Assistant Add-on: Cloudflared
+# Runs the healthcheck for cloudflared tunnel
+# ==============================================================================
+declare counter=0;
+declare treshold=24;
+declare status_ok=200;
+declare sleep=5;
+declare metrics_port=36500
+bashio::log.info "Starting Cloudflared Healthcheck for Home-Assistant add-on."
+
+while :
+do
+
+    # Wait for cloudflared metrics server to be available
+    bashio::net.wait_for "${metrics_port}"
+
+	# Get status of cloudflared
+	# 200 = Up, connected, ready
+	# 503 = 503, connection error (internet loss)
+	rc=$(curl -s localhost:"${metrics_port}"/ready | jq -r .status)
+	if [ "${rc}" == "${status_ok}" ]
+	then
+		counter=0;
+	else
+		counter=$((counter+1))
+		bashio::log.warning "Connection unavailable, rechecking in 5 seconds."
+		bashio::log.warning "Connection attempt ${counter}/${treshold} before restart."
+	fi
+	
+	bashio::log.debug "Metrics status: ${rc}"
+	bashio::log.debug "Connection attempt: ${counter}"
+
+	if [ "${counter}" == "${treshold}" ]; then
+        bashio::log.error "Restarting Cloudflared service"
+        s6-svc -r /var/run/s6-rc/servicedirs/cloudflared || bashio::exit.nok "Failed restarting cloudflared."
+        counter=0;
+	fi
+	# Wait a bit
+	sleep ${sleep};
+
+done

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
@@ -4,7 +4,7 @@
 # Runs the healthcheck for cloudflared tunnel
 # ==============================================================================
 declare counter=0;
-declare treshold=24;
+declare threshold=24;
 declare status_ok=200;
 declare sleep=5;
 declare metrics_port=36500
@@ -26,13 +26,13 @@ do
 	else
 		counter=$((counter+1))
 		bashio::log.warning "Connection unavailable, rechecking in 5 seconds."
-		bashio::log.warning "Connection attempt ${counter}/${treshold} before restart."
+		bashio::log.warning "Connection attempt ${counter}/${threshold} before restart."
 	fi
 	
 	bashio::log.debug "Metrics status: ${rc}"
 	bashio::log.debug "Connection attempt: ${counter}"
 
-	if [ "${counter}" == "${treshold}" ]; then
+	if [ "${counter}" == "${threshold}" ]; then
         bashio::log.error "Restarting Cloudflared service"
         s6-svc -r /var/run/s6-rc/servicedirs/cloudflared || bashio::exit.nok "Failed restarting cloudflared."
         counter=0;

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/type
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
# Proposed Changes

As discussed in #125 this PR implements a small healthcheck using the built-in metrics server.

To summarize the function: 
- Waiting for metrics server to be available (check if cloudflared is up and running, independent of connection status to clouflare edge servers)
- Check if status is 200 (= connected), all fine
- Otherwise increment counter
- Counter = 24 --> reinitialize cloudflared service (send restart command to s6-overlay)
- wait 5 sec

The threshold with 5 sec sleep and 24 loops is set to 120 seconds. I guess this should fit to most environments. 

I was reluctant to include this as a configuration option because the use cases are limited and the add-on configuration is already relatively complex  
What we can think about would be a general option to enable/disable all healthcheck functionality.

## Related Issues

> #125