### PR TITLE
Watchdog - fix metrics server binding

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
@@ -14,12 +14,12 @@ if bashio::config.true 'quick_tunnel'; then
     fi
     bashio::log.info "Connecting Cloudflared Quick Tunnel..."
     exec cloudflared --no-autoupdate \
-    tunnel --metrics="localhost:36500" --loglevel="${CLOUDFLARED_LOG}" --url "${ha_service_protocol}://homeassistant:$(bashio::core.port)"
+    tunnel --metrics="0.0.0.0:36500" --loglevel="${CLOUDFLARED_LOG}" --url "${ha_service_protocol}://homeassistant:$(bashio::core.port)"
 
 elif bashio::config.has_value 'tunnel_token' ; then
     tunnel_token=$(bashio::config 'tunnel_token')
     exec cloudflared --no-autoupdate \
-            tunnel --metrics="localhost:36500" --loglevel="${CLOUDFLARED_LOG}" run --token="${tunnel_token}"
+            tunnel --metrics="0.0.0.0:36500" --loglevel="${CLOUDFLARED_LOG}" run --token="${tunnel_token}"
 
 else
     data_path="/data"
@@ -39,5 +39,5 @@ else
     bashio::log.debug "using ${config} config file"
     
     exec cloudflared --origincert=${certificate} --no-autoupdate \
-        tunnel --config=${config} --metrics="localhost:36500" --loglevel="${CLOUDFLARED_LOG}" run "${tunnel_name}"
+        tunnel --config=${config} --metrics="0.0.0.0:36500" --loglevel="${CLOUDFLARED_LOG}" run "${tunnel_name}"
 fi


### PR DESCRIPTION
# Proposed Changes

Should provide Watchdog the possibility to contact metrics server for healthchecks issued from HA supervisor. 
This solution is working locally for ~60 mins now. 

If this isn't working we need to remove the watchdog string from add-on config.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
