### PR TITLE
Alter loglevel of unavailable connection dependent on counter

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
@@ -25,10 +25,16 @@ do
 		counter=0;
 	else
 		counter=$((counter+1))
-		bashio::log.warning "Connection unavailable, rechecking in 5 seconds."
-		bashio::log.warning "Connection attempt ${counter}/${threshold} before restart."
+		if [ "${counter}" -le 2 ]
+		then
+			bashio::log.debug "Connection unavailable, rechecking in 5 seconds."
+			bashio::log.debug "Connection attempt ${counter}/${threshold} before restart."
+		else
+			bashio::log.warning "Connection unavailable, rechecking in 5 seconds."
+			bashio::log.warning "Connection attempt ${counter}/${threshold} before restart."
+		fi
 	fi
-	
+
 	bashio::log.debug "Metrics status: ${rc}"
 	bashio::log.debug "Connection attempt: ${counter}"
 


### PR DESCRIPTION
# Proposed Changes

Alter loglevel of healthcheck if connection was not successful dependent on counter. Only starting from the third unsuccessful connection, it will be a warning. Before that, it will be a debug message.
This mainly helps reduce confusion for users when starting the add-on, where one warning is created most of the time.
