### PR TITLE
Optimize Cloudflare_release Workflow

### DIFF
--- a/.github/workflows/cloudflare_release.yaml
+++ b/.github/workflows/cloudflare_release.yaml
@@ -59,4 +59,5 @@ jobs:
           delete-branch: true
           title: "ℹ️ Update Cloudflared to version ${{ needs.cloudflare-release.outputs.latest_version }}"
           body: "Update Cloudflared to version ${{ needs.cloudflare-release.outputs.latest_version }}"
-          reviewers: "elcajon,brenner-tobias"
+          assignees: "elcajon,brenner-tobias"
+          labels: "dependencies"


### PR DESCRIPTION
# Proposed Changes

> Change reviewers to assignies for automatically created PR from cloudflare_release workflow. That way, (hopefully) not two reviews are needed, but all relevant parties are still notified.

> Add label "dependencies" to PR