### PR TITLE
Check active network connection first

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/healthcheck/run
@@ -33,6 +33,12 @@ do
 			bashio::log.warning "Connection unavailable, rechecking in 5 seconds."
 			bashio::log.warning "Connection attempt ${counter}/${threshold} before restart."
 		fi
+		
+		while ! ping -q -c 1 -W 1 1.1.1.1 > /dev/null
+		do
+			bashio::log.warning "Host has no internet connection, waiting 30 seconds..."
+			sleep 30
+		done
 	fi
 
 	bashio::log.debug "Metrics status: ${rc}"

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -412,12 +412,10 @@ resetWarp() {
 # Check for active network/internet connection
 # ------------------------------------------------------------------------------
 checkInternet() {
-    bashio::network.reload
-    while ! bashio::network.host_internet &> /dev/null
+    while ! ping -q -c 1 -W 1 1.1.1.1 > /dev/null
     do
         bashio::log.error "Host has no internet connection, waiting 30 seconds..."
         sleep 30
-        bashio::network.reload
     done
 }
 

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -412,7 +412,7 @@ resetWarp() {
 # Check for active network/internet connection
 # ------------------------------------------------------------------------------
 checkInternet() {
-    while [ ! bashio::network.host_internet ]
+    while ! bashio::network.host_internet &> /dev/null
     do
         bashio::log.error "Host has no internet connection, waiting 30 seconds..."
         sleep 30

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -408,6 +408,17 @@ resetWarp() {
     bashio::log.warning "Warp disabled successfully"
 }
 
+# ------------------------------------------------------------------------------
+# Check for active network/internet connection
+# ------------------------------------------------------------------------------
+checkInternet() {
+    while [ ! bashio::network.host_internet ]
+    do
+        bashio::log.error "Host has no internet connection, waiting 30 seconds..."
+        sleep 30
+    done
+}
+
 # ==============================================================================
 # RUN LOGIC
 # ------------------------------------------------------------------------------
@@ -419,6 +430,9 @@ data_path="/data"
 
 main() {
     bashio::log.trace "${FUNCNAME[0]}"
+    
+    # Check for active internet connection
+    checkInternet
 
     # Quick Tunnel with 0 config
     if bashio::config.true 'quick_tunnel'; then

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -412,10 +412,12 @@ resetWarp() {
 # Check for active network/internet connection
 # ------------------------------------------------------------------------------
 checkInternet() {
+    bashio::network.reload
     while ! bashio::network.host_internet &> /dev/null
     do
         bashio::log.error "Host has no internet connection, waiting 30 seconds..."
         sleep 30
+        bashio::network.reload
     done
 }
 


### PR DESCRIPTION
# Proposed Changes

This should fix all of the currently reported internet outage errors.

Given the following conditions:
- Connection outage while add-on connected --> implemented health check which restarts add-on
- Connection outage during start up phase --> this PR adds a check if host is connected to internet

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
