### PR TITLE
Tidy add-on description

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -52,7 +52,7 @@ still persists.
 
 Workaround:
 
-1. Create a new Cloudflare Account and invite it to your Cloudflare account
+1. Create a new Cloudflare account and invite it to your Cloudflare account
    that manages your Domain:\
    Cloudflare Dashboard -> Manage Account -> Members -> Invite Member
 1. Instead of using your primary account to authenticate the tunnel,
@@ -188,7 +188,7 @@ or directly to the tunnel URL that you can get from the CNAME entry of
 
 ### Option: `nginx_proxy_manager`
 
-If you want to use the Cloudflare Tunnel with the Add-on
+If you want to use Cloudflare Tunnel with the Add-on
 [Nginx Proxy Manager][nginx_proxy_manager], you can do so by setting this option.
 It will automatically set the catch_all_service to the internal URL of Nginx Proxy
 Manager. You do not have to add the option `catch_all_service` to your config (if
@@ -292,13 +292,12 @@ services (e.g. a homeassistant ingress rule) inside `config.yml`.
 ### Option: `warp_enable` (advanced option)
 
 If you want to route your home network(s) you can set this option to
-`true`. This will enable your cloudflared tunnel to proxy network traffic
-through your tunnel.
+`true`. This will enable proxying network traffic through your tunnel.
 
 Before setting this to `true` please have a look at the [cloudflared documentation][cloudflared-route].
 
-This add-on will take care of setting up cloudflared tunnel and routing specific
-configuration. All other configuration is up to you.
+This add-on will take care of setting up the Cloudflare Tunnel and routing
+specific configuration. All other configuration is up to you.
 
 An excerpt from the above documentation:
 
@@ -314,7 +313,7 @@ This option controls which routes will be added to your tunnel.
 
 This option is mandatory if `warp_enable` is set to `true`.
 
-See the example below on how to specifie networks (IP/CIDR) in
+See the example below on how to specify networks (IP/CIDR) in
 `warp_routes`.
 
 ```yaml
@@ -370,7 +369,7 @@ you are troubleshooting.
 
 ### Option: `reset_cloudflared_files`
 
-In case something went wrong or you want to reset your Cloudflare tunnel
+In case something went wrong or you want to reset your Cloudflare Tunnel
 for some other reason (e.g., switch to another Cloudflare account), you can reset
 all your local Cloudflare files by setting this option to `true`.
 
@@ -379,7 +378,7 @@ reset_cloudflared_files: true
 ```
 
 **Note**: _After deleting the files, the option `reset_cloudflared_files` will
-automaticaly be removed from the add-on configuration._
+automatically be removed from the add-on configuration._
 
 ### Option: `warp_reset`
 
@@ -400,13 +399,13 @@ removed from the add-on configuration._
 ### configuration.yaml
 
 Since Home Assistant blocks requests from proxies / reverse proxies, you have to
-tell your instance to allow requests from the Cloudflared Add-on. The add-on runs
+tell your instance to allow requests from the Cloudflared add-on. The add-on runs
 locally, so HA has to trust the docker network. In order to do so, add the
 following lines to your `/config/configuration.yaml` (there is no need to adapt
 anything in these lines since the IP range of the docker network is always the
 same):
 
-**Note**: _Remember to restart Home Assistance when the configuration is changed._
+**Note**: _Remember to restart Home Assistant when the configuration is changed._
 
 ```yaml
 http:
@@ -438,7 +437,7 @@ following [this article][domainarticle].
 
 ### Cloudflare
 
-Create a free Cloudflare Account at [cloudflare.com][cloudflare] and follow
+Create a free Cloudflare account at [cloudflare.com][cloudflare] and follow
 the tutorial [Getting started with Cloudflare][cloudflaretutorial].
 
 ## Authors & contributors

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -2,8 +2,8 @@
 name: Cloudflared
 version: dev
 slug: cloudflared
-description: "Use a Cloudflared tunnel (formerly Argo Tunnel)
-  to remotely connect to Home Assistant without opening any ports"
+description: "Use a Cloudflare Tunnel to remotely
+  connect to Home Assistant without opening any ports"
 url: "https://github.com/brenner-tobias/addon-cloudflared/"
 codenotary: dev@brenner.tech
 init: false

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # ==============================================================================
 # Home Assistant Add-on: Cloudflared
-# Runs the Cloudfalred tunnel for HomeAssistant
+# Runs the Cloudflare Tunnel for Home Assistant
 # ==============================================================================
 declare default_config=/tmp/config.json
 
@@ -12,7 +12,7 @@ if bashio::config.true 'quick_tunnel'; then
     else
         ha_service_protocol="http"
     fi
-    bashio::log.info "Connecting Cloudflared Quick Tunnel..."
+    bashio::log.info "Connecting Cloudflare Quick Tunnel..."
     exec cloudflared --no-autoupdate \
     tunnel --metrics="0.0.0.0:36500" --loglevel="${CLOUDFLARED_LOG}" --url "${ha_service_protocol}://homeassistant:$(bashio::core.port)"
 
@@ -35,9 +35,9 @@ else
     certificate="${data_path}/cert.pem"
     tunnel_name="$(bashio::config 'tunnel_name')"
 
-    bashio::log.info "Connecting Cloudflared Tunnel..."
+    bashio::log.info "Connecting Cloudflare Tunnel..."
     bashio::log.debug "using ${config} config file"
-    
+
     exec cloudflared --origincert=${certificate} --no-autoupdate \
         tunnel --config=${config} --metrics="0.0.0.0:36500" --loglevel="${CLOUDFLARED_LOG}" run "${tunnel_name}"
 fi

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/01-log-level.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/01-log-level.sh
@@ -9,7 +9,7 @@ declare log_level
 if bashio::config.exists log_level; then
 
     # Find the matching LOG_LEVEL
-    log_level=$(bashio::string.lower "$(bashio::config log_level)") 
+    log_level=$(bashio::string.lower "$(bashio::config log_level)")
     case "${log_level}" in
         all)
             log_level="${__BASHIO_LOG_LEVEL_ALL}"
@@ -47,7 +47,7 @@ if bashio::config.exists log_level; then
     bashio::log.blue "Log level is set to ${__BASHIO_LOG_LEVELS[$log_level]}"
 fi
 
-# Map HomeAssistant log levels to Cloudflared
+# Map Home Assistant log levels to Cloudflared
 if bashio::config.exists 'log_level' ; then
     case $(bashio::config 'log_level') in
         "trace") cloudflared_log="info";;
@@ -62,6 +62,6 @@ else
     cloudflared_log="info"
 fi
 
-# Write log level to S6 environment 
+# Write log level to S6 environment
 printf "%s" "${cloudflared_log}" > /var/run/s6/container_environment/CLOUDFLARED_LOG
 bashio::log.debug "Cloudflared log level set to \"${cloudflared_log}\""

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -3,7 +3,7 @@
 # ==============================================================================
 # Home Assistant Add-on: Cloudflared
 #
-# Configures the Cloudflared tunnel and creates the needed DNS entry under the
+# Configures the Cloudflare Tunnel and creates the needed DNS entry under the
 # given hostname(s)
 # ==============================================================================
 
@@ -139,7 +139,7 @@ createCertificate() {
 }
 
 # ------------------------------------------------------------------------------
-# Check if Cloudflared tunnel is existing
+# Check if Cloudflare Tunnel is existing
 # ------------------------------------------------------------------------------
 hasTunnel() {
     bashio::log.trace "${FUNCNAME[0]}:"
@@ -161,9 +161,9 @@ hasTunnel() {
     local existing_tunnel_name
     existing_tunnel_name=$(cloudflared --origincert="${data_path}/cert.pem" tunnel \
         list --output="json" --id="${tunnel_uuid}" | jq -er '.[].name')
-    bashio::log.debug "Existing Cloudflare tunnnel name: $existing_tunnel_name"
+    bashio::log.debug "Existing Cloudflare Tunnel name: $existing_tunnel_name"
     if [[ $tunnel_name != "$existing_tunnel_name" ]]; then
-        bashio::log.error "Existing Cloudflare tunnel name does not match add-on config."
+        bashio::log.error "Existing Cloudflare Tunnel name does not match add-on config."
         bashio::log.error "---------------------------------------"
         bashio::log.error "Add-on Configuration tunnel name: ${tunnel_name}"
         bashio::log.error "Tunnel credentials file tunnel name: ${existing_tunnel_name}"
@@ -172,13 +172,13 @@ hasTunnel() {
         bashio::log.error "or reset the add-on. Take a look at the documentation on how to reset the add-on"
         bashio::exit.nok
     fi
-    bashio::log.info "Existing Cloudflare tunnnel name matches config, proceeding with existing tunnel file"
+    bashio::log.info "Existing Cloudflare Tunnel name matches config, proceeding with existing tunnel file"
 
     return "${__BASHIO_EXIT_OK}"
 }
 
 # ------------------------------------------------------------------------------
-# Create cloudflare tunnel with name from HA-Add-on-Config
+# Create Cloudflare Tunnel with name from HA-Add-on-Config
 # ------------------------------------------------------------------------------
 createTunnel() {
     bashio::log.trace "${FUNCNAME[0]}"
@@ -194,7 +194,7 @@ createTunnel() {
 }
 
 # ------------------------------------------------------------------------------
-# Create cloudflare config with variables from HA-Add-on-Config
+# Create Cloudflare config with variables from HA-Add-on-Config
 # ------------------------------------------------------------------------------
 createConfig() {
     local ha_service_protocol
@@ -267,7 +267,7 @@ createConfig() {
     # Write content of config variable to config file for cloudflared
     bashio::jq "${config}" "." > "${default_config}"
 
-    # Validate config using Cloudflared
+    # Validate config using cloudflared
     bashio::log.info "Validating config file..."
     bashio::log.debug "Validating created config file: $(bashio::jq "${default_config}" ".")"
     cloudflared tunnel --config="${default_config}" --loglevel "${CLOUDFLARED_LOG}" ingress validate \
@@ -463,7 +463,7 @@ main() {
     fi
     if bashio::config.true 'custom_config' ; then
         if hasCustomConfig ; then
-            bashio::log.info "Finished setting-up the Cloudflare tunnel with custom config file"
+            bashio::log.info "Finished setting-up the Cloudflare Tunnel with custom config file"
             bashio::exit.ok
         fi
     fi
@@ -480,6 +480,6 @@ main() {
         createRoutes
     fi
 
-    bashio::log.info "Finished setting-up the Cloudflare tunnel"
+    bashio::log.info "Finished setting-up the Cloudflare Tunnel"
 }
 main "$@"

--- a/cloudflared/translations/en.yaml
+++ b/cloudflared/translations/en.yaml
@@ -5,7 +5,7 @@ configuration:
     description: >-
       Defines the log level for add-on and the Cloudflare service.
   external_hostname:
-    name: External Homeassistant Hostname
+    name: External Home Assistant Hostname
     description: >-
       Set this to your domain name or a subdomain that you want to use to
       access Home Assistant.
@@ -18,7 +18,7 @@ configuration:
   additional_hosts:
     name: Additional Hosts
     description: >-
-      Define a list of additional hosts to be routed by the Cloudflare tunnel.
+      Define a list of additional hosts to be routed by the Cloudflare Tunnel.
   catch_all_service:
     name: Catch-All Service
     description: >-
@@ -37,7 +37,7 @@ configuration:
   reset_cloudflared_files:
     name: Reset Cloudflared files
     description: >-
-      When enabled, the add-on configuration will be resetted upon next add-on
+      When enabled, the add-on configuration will be reset upon next add-on
       start.
   data_folder:
     name: Custom Data Folder
@@ -52,17 +52,17 @@ configuration:
     name: Enable Cloudflare Warp
     description: >-
       This option enables Cloudflare Warp functionality. Warp allows you to
-      route your whole network through the Cloudflare tunnel.
+      route your whole network through the Cloudflare Tunnel.
   warp_routes:
     name: Define Cloudflare Warp routes
     description: >-
-      Define networks to route through your Cloudflare tunnel if Warp function
+      Define networks to route through your Cloudflare Tunnel if Warp function
       is enabled.
   warp_reset:
     name: Reset Cloudflare Warp
     description: >-
       When enabled, the Cloudflare Warp related add-on configuration will
-      be resetted upon next add-on start.
+      be reset upon next add-on start.
   tunnel_token:
     name: Cloudflare Tunnel Token
     description: >-

--- a/docs/remote-tunnel.md
+++ b/docs/remote-tunnel.md
@@ -2,7 +2,7 @@
 
 ## About
 
-Follow the next steps to create a cloudflare managed tunnel with the
+Follow the next steps to create a Cloudflare Tunnel with the
 Cloudflare Zero Trust Dashboard and connect the Cloudflared Home Assistant add-on
 to use this tunnel.
 


### PR DESCRIPTION
"Use a Cloudflared tunnel" reads wrong to me. It's a Cloudflare Tunnel, and it's achieved via the Cloudflare Tunnel client (formerly Argo Tunnel) called `cloudflared`.

Perhaps the finer details of this don't need to be included in the description, but "Cloudflared tunnel" stood out as wrong to me.