### PR TITLE
Make external_hostname and tunnel_name optional

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -70,6 +70,7 @@ advanced configuration options.
 There are more advanced configuration options this add-on provides.
 Please check the index below for further information.
 
+- [`tunnel_name`](#option-tunnel_name)
 - [`additional_hosts`](#option-additional_hosts)
 - [`catch_all_service`](#option-catch_all_service)
 - [`nginx_proxy_manager`](#option-nginx_proxy_manager)
@@ -88,7 +89,6 @@ Example basic add-on configuration:
 
 ```yaml
 external_hostname: "ha.example.com"
-tunnel_name: "homeassistant"
 additional_hosts: []
 ```
 
@@ -96,7 +96,6 @@ Example extended add-on configuration:
 
 ```yaml
 external_hostname: "ha.example.com"
-tunnel_name: "homeassistant"
 additional_hosts:
   - hostname: "router.example.com"
     service: "http://192.168.1.1"
@@ -113,6 +112,17 @@ warp_routes:
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
+
+### Option: `tunnel_name`
+
+If you want to change the default tunnel name to something different than
+"homeassistant", you can do so by using this option.
+
+**Note**: _The tunnel name needs to be unique in your Cloudflare Account._
+
+```yaml
+tunnel_name: "myHomeAssistant"
+```
 
 ### Option: `additional_hosts`
 

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -33,7 +33,8 @@ and a manual step at the first set-up.
 
 The following instructions describe the necessary steps to use this add-on to expose your
 HA instance via the Cloudflare tunnel. If you only want to expose other services, you can do
-so by setting other configuration options shown [below](#configuration).
+so by setting other configuration options shown [below](#configuration) and leaving `external_hostname`
+empty.
 
 1. Add the `http` integration settings to your HA-config as described [below](#configurationyaml).
 1. Set the `external_hostname` add-on option with your domain name or a subdomain

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -31,10 +31,10 @@ and a manual step at the first set-up.
 
 ### Initial Add-on Setup for local tunnels
 
-The following instructions describe the necessary steps to use this add-on to expose
-your HA instance via the Cloudflare tunnel. If you only want to expose other services,
-you can do so by setting other configuration options shown [below](#configuration) and
-leaving `external_hostname` empty.
+The following instructions describe the necessary steps to use this add-on to
+expose your HA instance via the Cloudflare tunnel. If you only want to expose
+other services, you can do so by setting other configuration options shown
+[below](#configuration) and leaving `external_hostname` empty.
 
 1. Add the `http` integration settings to your HA-config as described [below](#configurationyaml).
 1. Set the `external_hostname` add-on option with your domain name or a subdomain

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -31,10 +31,10 @@ and a manual step at the first set-up.
 
 ### Initial Add-on Setup for local tunnels
 
-The following instructions describe the necessary steps to use this add-on to expose your
-HA instance via the Cloudflare tunnel. If you only want to expose other services, you can do
-so by setting other configuration options shown [below](#configuration) and leaving `external_hostname`
-empty.
+The following instructions describe the necessary steps to use this add-on to expose 
+your HA instance via the Cloudflare tunnel. If you only want to expose other services, 
+you can do so by setting other configuration options shown [below](#configuration) and 
+leaving `external_hostname` empty.
 
 1. Add the `http` integration settings to your HA-config as described [below](#configurationyaml).
 1. Set the `external_hostname` add-on option with your domain name or a subdomain

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -24,9 +24,6 @@ and a manual step at the first set-up.
 
 ### Prerequisites
 
-1. Before starting, please make sure to remove all other add-ons or configuration
-   entries handling SSL certificates, domain names and so on (e.g. DuckDNS) and
-   restart your Home Assistant instance.
 1. If you don't yet have a working Cloudflare set-up:
    Get a domain name and set-up Cloudflare. See section
    [Domain Name and Cloudflare Set-Up](#domain-name-and-cloudflare-set-up) for details.
@@ -34,7 +31,9 @@ and a manual step at the first set-up.
 
 ### Initial Add-on Setup for local tunnels
 
-The following instructions describe the minimum necessary steps to use this add-on:
+The following instructions describe the necessary steps to use this add-on to expose your
+HA instance via the Cloudflare tunnel. If you only want to expose other services, you can do
+so by setting other configuration options shown [below](#configuration).
 
 1. Add the `http` integration settings to your HA-config as described [below](#configurationyaml).
 1. Set the `external_hostname` add-on option with your domain name or a subdomain

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -29,6 +29,21 @@ and a manual step at the first set-up.
    [Domain Name and Cloudflare Set-Up](#domain-name-and-cloudflare-set-up) for details.
 1. **Decide whether to use a [local or managed tunnel][addon-remote-or-local].**
 
+### Initial Add-on Setup for remote tunnels
+
+If you created a Cloudflare Tunnel from the Zero Trust Dashboard, you can provide
+your tunnel token to connect to your remote managed tunnel.
+Keep in mind, when using this option, that you need to configure all
+hosts (including Home Assistant) by yourself.
+
+1. Add the `http` integration settings to your HA-config as described [below](#configurationyaml).
+1. Create a Cloudflare Tunnel in the Cloudflare Teams dashboard following
+   [this how-to][addon-remote-tunnel] for a step by step guide.
+1. Set `tunnel_token` to your [tunnel token][create-remote-managed-tunnel],
+   all other configuration will be ignored.
+1. Start the "Cloudflared" add-on, check the logs to see whether everything went
+   as expected.
+
 ### Initial Add-on Setup for local tunnels
 
 The following instructions describe the necessary steps to use this add-on to
@@ -45,13 +60,12 @@ other services, you can do so by setting other configuration options shown
 1. Check the logs of the "Cloudflared" add-on and **follow the instruction to authenticate
    at Cloudflare**.
    You need to copy a URL from the logs and visit it to authenticate.
-1. A tunnel and a DNS entry will be created and show up in your Cloudflare DNS /
-   Teams dashboard.
+1. A tunnel will be created and show up in your Cloudflare Teams dashboard.
 
 Please review the rest of this documentation for further information and more
 advanced configuration options.
 
-## Configuration
+## Configuration for local tunnels
 
 There are more advanced configuration options this add-on provides.
 Please check the index below for further information.
@@ -65,7 +79,6 @@ Please check the index below for further information.
 - [`warp_routes`](#option-warp_routes)
 - [`log_level`](#option-log_level)
 - [`warp_reset`](#option-warp_reset)
-- [`tunnel_token`](#option-tunnel_token)
 
 ### Overview: Add-on Configuration
 
@@ -276,22 +289,6 @@ warp_routes:
 **Note**: _By default, Cloudflare Zero Trust excludes traffic for private
 address spaces (RFC 191), you need to adapt the
 [Split Tunnel][cloudflared-route-st] configuration._
-
-### Option: `tunnel_token`
-
-If you created a Cloudflare Tunnel from the Zero Trust Dashboard, you can provide
-your tunnel token to connect to your remote managed tunnel.
-Keep in mind, when using this option, that you need to configure all
-hosts (including Home Assistant) by yourself.
-Set `tunnel_token` to your [tunnel token][create-remote-managed-tunnel],
-all other configuration will be ignored. After starting the addon, check the
-logs to see whether everything went as expected.
-
-Check out [this how-to][addon-remote-tunnel] to get a step by step
-guide on how to set up a remote managed tunnel with this add-on.
-
-Please note that you still have to add the `http` integration settings to your
-HA-config as described [here](#configurationyaml).
 
 ### Option: `log_level`
 

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -31,9 +31,9 @@ and a manual step at the first set-up.
 
 ### Initial Add-on Setup for local tunnels
 
-The following instructions describe the necessary steps to use this add-on to expose 
-your HA instance via the Cloudflare tunnel. If you only want to expose other services, 
-you can do so by setting other configuration options shown [below](#configuration) and 
+The following instructions describe the necessary steps to use this add-on to expose
+your HA instance via the Cloudflare tunnel. If you only want to expose other services,
+you can do so by setting other configuration options shown [below](#configuration) and
 leaving `external_hostname` empty.
 
 1. Add the `http` integration settings to your HA-config as described [below](#configurationyaml).

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -21,7 +21,6 @@ map:
   - config:rw
 options:
   external_hostname: ""
-  tunnel_name: "homeassistant"
   additional_hosts: []
   tunnel_token: ""
 schema:

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -26,6 +26,7 @@ options:
 schema:
   external_hostname: str?
   tunnel_name: str?
+  tunnel_token: str?
   additional_hosts:
     - hostname: str
       service: str
@@ -39,4 +40,3 @@ schema:
   warp_routes:
     - str?
   warp_reset: bool?
-  tunnel_token: str?

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -22,7 +22,6 @@ map:
 options:
   external_hostname: ""
   additional_hosts: []
-  tunnel_token: ""
 schema:
   external_hostname: str?
   tunnel_name: str?

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -29,15 +29,18 @@ checkConfig() {
         bashio::exit.ok "Running with Custom-Config and skipping further validations"
     fi
 
+    if bashio::config.is_empty 'external_hostname' && bashio::config.is_empty 'custom_config' &&
+        bashio::config.is_empty 'additional_hosts' && bashio::config.is_empty 'catch_all_service' &&
+        bashio::config.is_empty 'nginx_proxy_manager'; 
+    then
+        bashio::exit.nok "Cannot run without tunnel_token, custom_config, external_hostname or additional_hosts. Please set at least one of these add-on options."
+    fi
+
     # Check if 'external_hostname' includes a valid hostname 
     if bashio::config.has_value 'external_hostname' ; then
         if ! [[ $(bashio::config 'external_hostname') =~ ${validHostnameRegex} ]] ; then
             bashio::exit.nok "'$(bashio::config 'external_hostname')' is not a valid hostname. Please make sure not to include the protocol (e.g. 'https://') nor the port (e.g. ':8123') in the 'external_hostname'."
         fi
-    else
-        if bashio::config.is_empty 'additional_hosts' ; then
-          bashio::exit.nok "Cannot run without tunnel_token, custom_config, external_hostname or additional_hosts. Please set at least one of these add-on options."
-        fi  
     fi
 
     # Check if all defined 'additional_hosts' have non-empty strings as hostname and service

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -33,7 +33,7 @@ checkConfig() {
         bashio::config.is_empty 'additional_hosts' && bashio::config.is_empty 'catch_all_service' &&
         bashio::config.is_empty 'nginx_proxy_manager';
     then
-        bashio::exit.nok "Cannot run without tunnel_token, custom_config, external_hostname or additional_hosts. Please set at least one of these add-on options."
+        bashio::exit.nok "Cannot run without tunnel_token, external_hostname, custom_config, additional_hosts, catch_all_service or nginx_proxy_manager. Please set at least one of these add-on options."
     fi
 
     # Check if 'external_hostname' includes a valid hostname 
@@ -396,7 +396,7 @@ resetWarp() {
 # ------------------------------------------------------------------------------
 declare default_config=/tmp/config.json
 external_hostname=""
-tunnel_name=""
+tunnel_name="homeassistant"
 tunnel_uuid=""
 data_path="/data"
 
@@ -423,8 +423,11 @@ main() {
 
     checkConfig
 
+    if bashio::config.has_value 'tunnel_name' ; then
+        tunnel_name="$(bashio::config 'tunnel_name')"
+    fi
+
     external_hostname="$(bashio::config 'external_hostname')"
-    tunnel_name="$(bashio::config 'tunnel_name')"
 
     if ! hasCertificate ; then
         createCertificate

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -16,11 +16,6 @@ checkConfig() {
 
     local validHostnameRegex="^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$"
 
-    # Check if 'tunnel_name' is a non-empty string
-    if bashio::config.is_empty 'tunnel_name' ; then
-        bashio::exit.nok "'tunnel_name' is empty, please enter a valid String"
-    fi
-
     # Check if 'custom_config' and 'data_folder' are both included in config.
     if bashio::config.true 'custom_config' ; then
         if ! bashio::config.has_value 'data_folder' ; then

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/10-cloudflared-config.sh
@@ -31,7 +31,7 @@ checkConfig() {
 
     if bashio::config.is_empty 'external_hostname' && bashio::config.is_empty 'custom_config' &&
         bashio::config.is_empty 'additional_hosts' && bashio::config.is_empty 'catch_all_service' &&
-        bashio::config.is_empty 'nginx_proxy_manager'; 
+        bashio::config.is_empty 'nginx_proxy_manager';
     then
         bashio::exit.nok "Cannot run without tunnel_token, custom_config, external_hostname or additional_hosts. Please set at least one of these add-on options."
     fi

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -5,23 +5,22 @@
 Check the following information if you are unsure which tunnel type to use
 with this add-on.
 
+In general you can use both tunnel types (remote or local) with this add-on.
+
+If you like to configure your tunnel from within the add-on configuration page
+and are happy with the given options, the local tunnel is what you are looking
+for. Take a look at the [add-on docs](../cloudflared/DOCS.md), to see what
+options can be used.
+
+If you want to set up a more sophisticated tunnel with full flexibility and
+maintain it from the Cloudflare Zero Trust Dashboard, you should go for the
+remote managed tunnel. Have a look at this [how-to](remote-tunnel.md).
+
 ## Cloudflare Documentation
 
 Revise the [official Cloudflare documentation][cloudflare-docs]
 to see latest information.
 
 ![Cloudflare Docs Picture](images/10.png)
-
-## What does this add-on provide
-
-In general you can use both tunnel types (remote or local) with this add-on.
-
-If you like to configure your tunnel from within the add-on configuration page,
-the local tunnel is what you are looking for. Take a look at the
-[add-on docs](../cloudflared/DOCS.md), to see what options can be used.
-
-If you want to set up and maintain your tunnel from the Cloudflare Zero Trust
-Dashboard, you should go for the remote managed tunnel. Have a look at this
-[how-to](remote-tunnel.md).
 
 [cloudflare-docs]: https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/


### PR DESCRIPTION
# Proposed Changes

- Enable usage without using _external_host_ (for _custom_config_, _additional_hosts_, _catch_all_service_ or _nginx_proxy_manager_
- Make _tunnel_name_ optional with default "homeassistant"

## Related Issues

#190
