### PR TITLE
Change order to reflect the default options positions

### DIFF
--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -24,12 +24,12 @@ options:
   additional_hosts: []
 schema:
   external_hostname: str?
-  tunnel_name: str?
-  tunnel_token: str?
   additional_hosts:
     - hostname: str
       service: str
       disableChunkedEncoding: bool?
+  tunnel_name: str?
+  tunnel_token: str?
   catch_all_service: str?
   nginx_proxy_manager: bool?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?


### PR DESCRIPTION
# Proposed Changes

- Change the order of the options to have the ones with default values at the very top. That way, they are not "jumping" if you toggle the "show optional options" switch.