### PR TITLE
Extend troubleshooting section

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -300,6 +300,16 @@ Plase this rule as the last in your ruleset (free account can have up to 5 such 
 
 You can Watch know _Security / Events_ log for possible rejections for traffic not matched by the first explicit _Allow_ rule and fine-tune it as needed.
 
+The problem is apparently caused by Cloudflare falsely detect app location update traffic as a malicious bot attacking the web-site. The app may use unusual header, which are not typical for human browser-based behavior.
+
+You may noticed that after a while you can remove the rule and the traffic is still accepted. This is probably because Cloudflare algorithms learned that the traffic it legitimate.
+
+If you still see that some sporadic 503 errors here and there, when working over Cloudflare tunnel, you may try:
+
+1. Disabling _Bot Fight Mode_ in Security / Bot.
+2. Disabling _Browser Integrity Check_ in _Security Setting.
+3. Set _Security Level_ to _Low_ to reduce risk of showing Challenge page to the _Companion App_.
+
 ### Securing access to your Cloudflare account
 
 The add-on downloads after authentication a `cert.pem` file to authenticate

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -287,9 +287,9 @@ For that, navigate to _Cloudflare / Security / WAF / Create firewall rule_ and c
 There _xx.yyy.zz_ is your domain where you expose your HA installation.
 Set _action_ to this rule to _allow_.
 
-Once you saved, the rule will be applied immediatel. You can try force-updating location via _Settings / Location / Update location_.
+Once you saved, the rule will be applied immediately. You can now force app updating location by clicking the link _Settings / Location / Update location_.
 
-In _Settings / Debugging / Event Log_ you will see notifications about successful update:
+In _Settings / Debugging / Event Log_ you should see notifications about successful update:
 
 ```
 Location Update: Location update triggered by user

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -307,7 +307,7 @@ You may noticed that after a while you can remove the rule and the traffic is st
 If you still see that some sporadic 503 errors here and there, when working over Cloudflare tunnel, you may try:
 
 1. Disabling _Bot Fight Mode_ in Security / Bot.
-2. Disabling _Browser Integrity Check_ in _Security Setting.
+2. Disabling _Browser Integrity Check_ in _Security Setting_.
 3. Set _Security Level_ to _Low_ to reduce risk of showing Challenge page to the _Companion App_.
 
 ### Securing access to your Cloudflare account


### PR DESCRIPTION
Extend troubleshooting information about fix for _Webhook failed with the status code 503 while updating location_ error.

# Proposed Changes

This PR extends _Troubleshooting_ section with the suggestion on how to fix _Webhook failed with the status code 503 while updating location_ error caused by Cloudflare blocking legitimate Home Assistant Companion App traffic (apparently false positive on bot detection).

The solution builds up on the method suggested in 
https://community.home-assistant.io/t/new-add-on-cloudflared/361637/420?u=0anton

## Related Issues

https://community.home-assistant.io/t/new-add-on-cloudflared/361637/417?u=0anton
