### PR TITLE
Auto-Close Renovate "Dependency Dashboard"-Issue

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",


### PR DESCRIPTION
# Proposed Changes
Renovate-Bot will close/open the related "Dependency Dashboard" issue depending on availability of updates.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
