### PR TITLE
Fix name of Zero Trust dashboard and link in Error Message

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -146,7 +146,7 @@ createTunnel() {
     cloudflared --origincert="${data_path}/cert.pem" --cred-file="${data_path}/tunnel.json" tunnel --loglevel "${CLOUDFLARED_LOG}" create "${tunnel_name}" \
     || bashio::exit.nok "Failed to create tunnel.
     Please check the Cloudflare Zero Trust Dashboard for an existing tunnel with the name ${tunnel_name} and delete it:
-    https://one.dash.cloudflare.com / Access / Tunnels"
+    Visit https://one.dash.cloudflare.com, then click on Access / Tunnels"
 
     bashio::log.debug "Created new tunnel: $(cat "${data_path}"/tunnel.json)"
 

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -145,8 +145,8 @@ createTunnel() {
     bashio::log.info "Creating new tunnel..."
     cloudflared --origincert="${data_path}/cert.pem" --cred-file="${data_path}/tunnel.json" tunnel --loglevel "${CLOUDFLARED_LOG}" create "${tunnel_name}" \
     || bashio::exit.nok "Failed to create tunnel.
-    Please check the Cloudflare Teams Dashboard for an existing tunnel with the name ${tunnel_name} and delete it:
-    https://dash.teams.cloudflare.com/ Access / Tunnels"
+    Please check the Cloudflare Zero Trust Dashboard for an existing tunnel with the name ${tunnel_name} and delete it:
+    https://one.dash.cloudflare.com / Access / Tunnels"
 
     bashio::log.debug "Created new tunnel: $(cat "${data_path}"/tunnel.json)"
 


### PR DESCRIPTION
# Proposed Changes

Fix link to Cloudflare Zero Trust Dashboard in the error message if an existing tunnel with the same name was found.
