### PR TITLE
Remove Disclaimer to section 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ SOFTWARE.
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [cloudflare-sssa]: https://www.cloudflare.com/terms/
-[cloudflare-sssa-28]: https://www.cloudflare.com/terms/#:~:text=2.8%20Limitation%20on%20Serving%20Non%2DHTML%20Content
 [docs]: cloudflared/DOCS.md
 [domainarticle]: https://www.linkedin.com/pulse/what-do-domain-name-how-get-one-free-tobias-brenner?trk=public_post-content_share-article
 [github-actions-shield]: https://github.com/brenner-tobias/addon-cloudflared/workflows/CI/badge.svg

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ connection.
 
 **To use this add-on, you have to own a domain name (e.g. example.com) that is
 using Cloudflare for its DNS entries. You can find more information about that
-in our [Wiki][wiki]**
+in our [Wiki][wiki]**.
 
 [:books: Read the full add-on documentation][docs]
 
@@ -34,8 +34,7 @@ in our [Wiki][wiki]**
 
 Please make sure you comply with the
 [Cloudflare Self-Serve Subscription Agreement][cloudflare-sssa] when using this
-add-on. For example [section 2.8][cloudflare-sssa-28] could be breached when
-streaming videos (e.g. Plex) or other non-HTML content.
+add-on.
 
 ## Installation
 

--- a/cloudflared/.README.j2
+++ b/cloudflared/.README.j2
@@ -17,14 +17,13 @@ connection.
 
 **To use this add-on, you have to own a domain name (e.g. example.com) that is
 using Cloudflare for its DNS entries. You can find more information about that
-in our [Wiki][wiki]**
+in our [Wiki][wiki]**.
 
 ## Disclaimer
 
 Please make sure to be compliant with the
 [Cloudflare Self-Serve Subscription Agreement][cloudflare-sssa] when using this
-add-on. Especially [section 2.8][cloudflare-sssa-28] could be breached when
-mainly streaming videos or other Non-HTML content.
+add-on.
 
 {% if channel == "edge" %}
 ## WARNING! THIS IS AN EDGE VERSION!
@@ -66,7 +65,6 @@ If you are more interested in stable releases of our add-ons:
 
 {% endif %}
 [cloudflare-sssa]: https://www.cloudflare.com/terms/
-[cloudflare-sssa-28]: https://www.cloudflare.com/terms/#:~:text=2.8%20Limitation%20on%20Serving%20Non%2DHTML%20Content
 [domainarticle]: https://www.linkedin.com/pulse/what-do-domain-name-how-get-one-free-tobias-brenner?trk=public_post-content_share-article
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -10,8 +10,7 @@ connection.
 
 Please make sure you comply with the
 [Cloudflare Self-Serve Subscription Agreement][cloudflare-sssa] when using this
-add-on. For example [section 2.8][cloudflare-sssa-28] could be breached when
-streaming videos (e.g. Plex) or other non-HTML content.
+add-on.
 
 ## Initial setup
 
@@ -304,7 +303,6 @@ SOFTWARE.
 [addon-wiki]: https://github.com/brenner-tobias/addon-cloudflared/wiki
 [advancedconfiguration]: https://www.home-assistant.io/getting-started/configuration/
 [cloudflare-sssa]: https://www.cloudflare.com/en-gb/terms/
-[cloudflare-sssa-28]: https://www.cloudflare.com/en-gb/terms/#:~:text=2.8%20Limitation%20on%20Serving%20Non%2DHTML%20Content
 [how-tos]: https://github.com/brenner-tobias/addon-cloudflared/wiki/How-tos
 [nginx_proxy_manager]: https://github.com/hassio-addons/addon-nginx-proxy-manager
 [tobias]: https://github.com/brenner-tobias


### PR DESCRIPTION
# Proposed Changes

Section 2.8 of the Cloudflare Self-Serve Subscription Agreement does not exist anymore. Therefor there is no need to show this as an example. Since it is still relevant to comply with the SSSA, the general disclaimer will remain in place.

## Related Issues

Closes #405
