### PR TITLE
Update .yamllint for Renovate CI updates

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -22,6 +22,8 @@ rules:
     min-spaces-after: 1
     max-spaces-after: 1
   comments:
+    ignore: |
+      .github/workflows/
     level: error
     require-starting-space: true
     min-spaces-from-content: 2


### PR DESCRIPTION
# Proposed Changes

This should fix the yamllint error blocking #469 from passing linter action.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
