### PR TITLE
Update validHostnames to also allow Umlauts in Domain Name, execpt TLD

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -14,7 +14,7 @@ checkConfig() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::log.info "Checking add-on config..."
 
-    local validHostnameRegex="^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$"
+    local validHostnameRegex="^(([\p{Ll}\p{Nd}]|[\p{Ll}\p{Nd}][\p{Ll}\p{Nd}\-]*[\p{Ll}\p{Nd}])\.)+([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$"
 
     # Check for minimum configuration options
     if bashio::config.is_empty 'external_hostname' && bashio::config.is_empty 'additional_hosts' &&


### PR DESCRIPTION
# Proposed Changes

Update the Regex for allowed Domain Names to include Umlauts.

Some considerations from my change:

1. In the part "left" of the TLD (so before the last .) I switched to [Unicode Categories](https://www.regular-expressions.info/unicode.html) for any lowercase letter `\p{Ll}` or decimal digit number `\p{Nd}`. I also changed the Quantifier before the TLD to a `+` to check for at least one "." and something before that in the domain name.
2. For the TLD itself, I did not make these changes, since there are from my knowledge no TLDs with Umlaute.

## Related Issues

closes #496 
