### PR TITLE
Accept Umlauts & regular latin characters

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -14,7 +14,7 @@ checkConfig() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::log.info "Checking add-on config..."
 
-    local validHostnameRegex="^(([\p{Ll}\p{Nd}]|[\p{Ll}\p{Nd}][\p{Ll}\p{Nd}\-]*[\p{Ll}\p{Nd}])\.)+([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$"
+    local validHostnameRegex="^(([\p{Ll}\w]|[\p{Ll}\w][\p{Ll}\w\-]*[\p{Ll}\w])\.)*([\p{Ll}\w]|[\p{Ll}\w][\p{Ll}\w\-]*[\p{Ll}\w])$"
 
     # Check for minimum configuration options
     if bashio::config.is_empty 'external_hostname' && bashio::config.is_empty 'additional_hosts' &&

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -14,7 +14,7 @@ checkConfig() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::log.info "Checking add-on config..."
 
-    local validHostnameRegex="^(([\p{Ll}\w]|[\p{Ll}\w][\p{Ll}\w\-]*[\p{Ll}\w])\.)*([\p{Ll}\w]|[\p{Ll}\w][\p{Ll}\w\-]*[\p{Ll}\w])$"
+    local validHostnameRegex="^(([\w]|[\w][\w\-]*[\w])\.)*(\w]|[\w][\w\-]*[\w])$"
 
     # Check for minimum configuration options
     if bashio::config.is_empty 'external_hostname' && bashio::config.is_empty 'additional_hosts' &&


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Makes the regex work as before and keeps the umlauts  change while simplifies the regex logic as \w is the same as [a-zA-Z0-9_]

## Related Issues
Fixes #500 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
