### PR TITLE
Fix tegex with old approach plus Umlauts

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -14,7 +14,7 @@ checkConfig() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::log.info "Checking add-on config..."
 
-    local validHostnameRegex="^(([\p{Ll}\p{Nd}]|[\p{Ll}\p{Nd}][\p{Ll}\p{Nd}\-]*[\p{Ll}\p{Nd}])\.)+([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$"
+    local validHostnameRegex="^(([a-z0-9äöüß]|[a-z0-9äöüß][a-z0-9äöüß\-]*[a-z0-9äöüß])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$"
 
     # Check for minimum configuration options
     if bashio::config.is_empty 'external_hostname' && bashio::config.is_empty 'additional_hosts' &&


### PR DESCRIPTION
# Proposed Changes

Revert to the old Regex for valid hostnames and include ä,ö,ü,ß as well
