### PR TITLE
Remove mapped folders

### DIFF
--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -15,10 +15,6 @@ arch:
   - armhf
   - armv7
   - i386
-map:
-  - ssl:rw
-  - share:rw
-  - config:rw
 options:
   external_hostname: ""
   additional_hosts: []


### PR DESCRIPTION
# Proposed Changes

There have been some changes on how to map folders (like config, share, ssl, backup...) into containers.
As we don't provide the option to set a specific data path any longer we can safely remove the mappings.

We can think about changing the default /data path to the new [add-on config structure](https://developers.home-assistant.io/docs/add-ons/configuration#add-on-advanced-options) so people will be able to get there tunnel.json and cert.pem easier. But I really don't know if it would be that useful. We also have a new source of errors if the files can be edited manually...

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
