### PR TITLE
Drop Support i386 & armhf

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64|armv7):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
+[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [cloudflare-sssa]: https://www.cloudflare.com/terms/
 [docs]: cloudflared/DOCS.md
@@ -87,7 +87,7 @@ SOFTWARE.
 [github-actions-shield]: https://github.com/brenner-tobias/addon-cloudflared/workflows/CI/badge.svg
 [github-actions]: https://github.com/brenner-tobias/addon-cloudflared//actions
 [ha-addons]: https://github.com/brenner-tobias/ha-addons
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg
+[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/brenner-tobias/addon-cloudflared/issues
 [license-shield]: https://img.shields.io/github/license/brenner-tobias/addon-cloudflared
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg

--- a/cloudflared/build.yaml
+++ b/cloudflared/build.yaml
@@ -2,9 +2,7 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base/aarch64:15.0.1
   amd64: ghcr.io/hassio-addons/base/amd64:15.0.1
-  armhf: ghcr.io/hassio-addons/base/armhf:15.0.1
   armv7: ghcr.io/hassio-addons/base/armv7:15.0.1
-  i386: ghcr.io/hassio-addons/base/i386:15.0.1
 codenotary:
   base_image: codenotary@frenck.dev
   signer: dev@brenner.tech

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -12,9 +12,7 @@ hassio_role: homeassistant
 arch:
   - aarch64
   - amd64
-  - armhf
   - armv7
-  - i386
 options:
   external_hostname: ""
   additional_hosts: []

--- a/cloudflared/rootfs/build.sh
+++ b/cloudflared/rootfs/build.sh
@@ -19,16 +19,8 @@ case $arch in
         arch="arm64"
     ;;
 
-    "armhf")
-        arch="arm"
-    ;;
-
     "armv7")
         arch="arm"
-    ;;
-
-    "i386")
-        arch="386"
     ;;
 esac
 


### PR DESCRIPTION
# Proposed Changes

I would like to discuss if we should / want to / have to drop support for armhf & i386.
The support for those architectures was [dropped in the example addon](https://github.com/hassio-addons/addon-example/pull/153) as well as all major Home Assistant Community Add-ons.

For now, a base image is still available, though I am not sure which direction this is going and if we should already follow with not supporting these architectures anymore.

I would very much appreciate your thoughts.