### PR TITLE
Add shield.io for active installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
+![Reported Installations][installations-shield-stable]
 
 Connect remotely to your Home Assistant and other services, without opening ports
 using Cloudflare Tunnel.
@@ -98,3 +99,4 @@ SOFTWARE.
 [my-ha-badge]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
 [my-ha-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fbrenner-tobias%2Fha-addons
 [wiki]: https://github.com/brenner-tobias/addon-cloudflared/wiki/How-tos
+[installations-shield-stable]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Faddons.json&query=%24%5B%229074a9fa_cloudflared%22%5D.total&label=Reported%20Installations&link=https%3A%2F%2Fanalytics.home-assistant.io/add-ons

--- a/cloudflared/.README.j2
+++ b/cloudflared/.README.j2
@@ -3,6 +3,14 @@
 [![GitHub Release][releases-shield]][releases]
 ![Project Stage][project-stage-shield]
 ![Project Maintenance][maintenance-shield]
+{% if channel == "stable" %}
+![Reported Installations][installations-shield-stable]
+
+{%- else -%}
+![Reported Installations][installations-shield-edge]
+
+{% endif %}
+
 
 Connect remotely to your Home Assistant instance without opening any ports using
 Cloudflared.
@@ -71,3 +79,5 @@ If you are more interested in stable releases of our add-ons:
 [releases-shield]: https://img.shields.io/github/v/release/brenner-tobias/addon-cloudflared?include_prereleases
 [releases]: https://github.com/brenner-tobias/addon-cloudflared/releases
 [wiki]: https://github.com/brenner-tobias/addon-cloudflared/wiki/How-tos
+[installations-shield-edge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Faddons.json&query=%24%5B%22ffd6a162_cloudflared%22%5D.total&label=Reported%20Installations&link=https%3A%2F%2Fanalytics.home-assistant.io/add-ons
+[installations-shield-stable]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Faddons.json&query=%24%5B%229074a9fa_cloudflared%22%5D.total&label=Reported%20Installations&link=https%3A%2F%2Fanalytics.home-assistant.io/add-ons


### PR DESCRIPTION
# Proposed Changes

Not really useful but nice to see and share the amount of active (and reported via analytics) add-on installations. This PR will show the badge on the HA add-on Info Screen depending von the used repo and shows the stable Info badge for this repos main README.

Stable installations: ![Reported Installations][installations-shield-stable]
Edge installations: ![Reported Installations][installations-shield-edge]

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
[installations-shield-edge]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Faddons.json&query=%24%5B%22ffd6a162_cloudflared%22%5D.total&label=Reported%20Installations&link=https%3A%2F%2Fanalytics.home-assistant.io/add-ons
[installations-shield-stable]: https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fanalytics.home-assistant.io%2Faddons.json&query=%24%5B%229074a9fa_cloudflared%22%5D.total&label=Reported%20Installations&link=https%3A%2F%2Fanalytics.home-assistant.io/add-ons