### PR TITLE
Add --loglevel as valid run_parameter

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -234,6 +234,7 @@ Valid parameters to add are:
 - --edge-ip-version
 - --grace-period
 - --logfile
+- --loglevel
 - --pidfile
 - --protocol
 - --region
@@ -255,6 +256,7 @@ as root. This path can be accessed, for example, via the VS-code add-on via
 run_parameters:
   - "--region=us"
   - "--protocol=http2"
+  - "--loglevel=debug"
 ```
 
 ### Option: `log_level`

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -30,5 +30,5 @@ schema:
   tunnel_token: str?
   post_quantum: bool?
   run_parameters:
-    - match(^(--edge-bind-address|--edge-ip-version|--grace-period|--ha-connections|--logfile|--pidfile|--protocol|--region|--retries|--tag)=.*$)?
+    - match(^(--edge-bind-address|--edge-ip-version|--grace-period|--ha-connections|--logfile|--loglevel|--pidfile|--protocol|--region|--retries|--tag)=.*$)?
   log_level: list(trace|debug|info|notice|warning|error|fatal)?


### PR DESCRIPTION
# Proposed Changes

SSIA

The `run_parameters` `--loglevel` option will override our previously set --loglevel option which should be fine as it has to be set on purpose. 

## Related Issues


resolves #607 
