### PR TITLE
Refactor log level logic

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -265,6 +265,9 @@ The `log_level` option controls the level of log output by the addon and can
 be changed to be more or less verbose, which might be useful when you are
 dealing with an unknown issue.
 
+**Note**: _If you want to change the log level of the tunnel itself you can
+use the `run_parameters` `--loglevel` option._
+
 ```yaml
 log_level: debug
 ```

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/cloudflared/run
@@ -11,7 +11,6 @@ declare -a options
 # Set common cloudflared tunnel options
 options+=(--no-autoupdate)
 options+=(--metrics="0.0.0.0:36500")
-options+=(--loglevel="${CLOUDFLARED_LOG}")
 
 # Check for post_quantum option
 if bashio::config.true 'post_quantum' ; then

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -306,6 +306,30 @@ createDNS() {
     fi
 }
 
+# ------------------------------------------------------------------------------
+# Set Cloudflared log level
+# ------------------------------------------------------------------------------
+setCloudflaredLogLevel() {
+
+# Set cloudflared log to "info" as default
+CLOUDFLARED_LOG="info"
+
+# Check if user wishes to change log severity
+if bashio::config.has_value 'run_parameters' ; then
+    bashio::log.trace "bashio::config.has_value 'run_parameters'"
+    for run_parameter in $(bashio::config 'run_parameters'); do
+        bashio::log.trace "Checking run_parameter: ${run_parameter}"
+        if [[ $run_parameter == --loglevel=* ]]; then
+            CLOUDFLARED_LOG=${run_parameter#*=}
+            bashio::log.trace "Setting CLOUDFLARED_LOG to: ${run_parameter#*=}"
+        fi
+    done
+fi
+
+bashio::log.debug "Cloudflared log level set to \"${CLOUDFLARED_LOG}\""
+
+}
+
 # ==============================================================================
 # RUN LOGIC
 # ------------------------------------------------------------------------------
@@ -317,6 +341,8 @@ data_path="/data"
 
 main() {
     bashio::log.trace "${FUNCNAME[0]}"
+
+    setCloudflaredLogLevel
 
     # Run connectivity checks if debug mode activated
     if bashio::debug ; then

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -306,34 +306,6 @@ createDNS() {
     fi
 }
 
-# ------------------------------------------------------------------------------
-# Set Cloudflared log level
-# ------------------------------------------------------------------------------
-setCloudflaredLogLevel() {
-local log
-
-# Map Home Assistant log levels to Cloudflared
-if bashio::config.exists 'log_level' ; then
-    case $(bashio::config 'log_level') in
-        "trace") log="info";;
-        "debug") log="info";;
-        "info") log="info";;
-        "notice") log="info";;
-        "warning") log="warn";;
-        "error") log="error";;
-        "fatal") log="fatal";;
-    esac
-else
-    log="info"
-fi
-
-# Write log level to S6 environment
-printf "%s" "${log}" > /var/run/s6/container_environment/CLOUDFLARED_LOG
-CLOUDFLARED_LOG=${log}
-bashio::log.debug "Cloudflared log level set to \"${log}\""
-
-}
-
 # ==============================================================================
 # RUN LOGIC
 # ------------------------------------------------------------------------------
@@ -345,8 +317,6 @@ data_path="/data"
 
 main() {
     bashio::log.trace "${FUNCNAME[0]}"
-
-    setCloudflaredLogLevel
 
     # Run connectivity checks if debug mode activated
     if bashio::debug ; then

--- a/cloudflared/translations/de.yaml
+++ b/cloudflared/translations/de.yaml
@@ -3,7 +3,7 @@ configuration:
   log_level:
     name: Log Level
     description: >-
-      Legt das Log-Level für das Add-on und den Cloudflared-Dienst fest.
+      Legt das Log-Level für das Add-on fest.
   external_hostname:
     name: Externer Hostname von Home Assistant
     description: >-

--- a/cloudflared/translations/en.yaml
+++ b/cloudflared/translations/en.yaml
@@ -3,7 +3,7 @@ configuration:
   log_level:
     name: Log Level
     description: >-
-      Defines the log level for add-on and the Cloudflare service.
+      Defines the log level for the add-on.
   external_hostname:
     name: External Home Assistant Hostname
     description: >-

--- a/cloudflared/translations/nl.yaml
+++ b/cloudflared/translations/nl.yaml
@@ -3,7 +3,7 @@ configuration:
   log_level:
     name: Log Level
     description: >-
-      Beschrijft het log level voor add-on en de Cloudflare service.
+      Beschrijft het log level voor de add-on.
   external_hostname:
     name: Externe Hostname voor Home Assistant
     description: >-


### PR DESCRIPTION
# Proposed Changes

As discussed the PR removes the connection from our `log_level` add-on option to the cloudflared tunnel log level.
`log_level` from now on sets the add-on log level only
`run-parameters` `--loglevel` can be used to change cloudflared tunnel severity (defaults to `info` if not set)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
