### PR TITLE
Remove remnants of armhf and i386 from workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,14 +146,10 @@ jobs:
           echo "from=$from" >> $GITHUB_OUTPUT
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
             echo "platform=linux/amd64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
-            echo "platform=linux/386" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
-            echo "platform=linux/arm/v6" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "platform=linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "platform=linux/arm64/v8" >> $GITHUB_OUTPUT
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,7 +149,7 @@ jobs:
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "platform=linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+            echo "platform=linux/arm64/v8" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -90,14 +90,10 @@ jobs:
           echo "from=$from" >> $GITHUB_OUTPUT
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
             echo "platform=linux/amd64" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
-            echo "platform=linux/386" >> $GITHUB_OUTPUT
-          elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
-            echo "platform=linux/arm/v6" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "platform=linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "platform=linux/arm64/v8" >> $GITHUB_OUTPUT
+            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,7 +93,7 @@ jobs:
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
             echo "platform=linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "platform=linux/arm64" >> $GITHUB_OUTPUT
+            echo "platform=linux/arm64/v8" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1


### PR DESCRIPTION
# Proposed Changes

Remove the remnants of `armhf` and `i386` from workflows from GitHub Actions workflows.

~Also, it simplifies the `linux/arm64/v8` platform to just `linux/arm64` to align with the examples from https://docs.docker.com/build/building/multi-platform. It works the same (let me know if you disagree).~

## Related Issues

- #538
