### PR TITLE
Change runtime to avoid peek time and rate limits

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -4,7 +4,7 @@ name: Lock
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "3 25 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Proposed Changes

Change runtime of lock action to avoid peek times and rate limits

## Related Issues

https://github.com/dessant/lock-threads/issues/48
