### PR TITLE
🎆 Happy New Year 2025 - Update maintenance & license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 Tobias Brenner
+Copyright (c) 2025 Tobias Brenner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ check [the contributor's page][contributors].
 
 MIT License
 
-Copyright (c) 2024 Tobias Brenner
+Copyright (c) 2025 Tobias Brenner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -101,7 +101,7 @@ SOFTWARE.
 [i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/brenner-tobias/addon-cloudflared/issues
 [license-shield]: https://img.shields.io/github/license/brenner-tobias/addon-cloudflared
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2024.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [releases-shield]: https://img.shields.io/github/v/release/brenner-tobias/addon-cloudflared?include_prereleases
 [releases]: https://github.com/brenner-tobias/addon-cloudflared/releases

--- a/cloudflared/.README.j2
+++ b/cloudflared/.README.j2
@@ -74,7 +74,7 @@ If you are more interested in stable releases of our add-ons:
 {% endif %}
 [cloudflare-sssa]: https://www.cloudflare.com/terms/
 [domainarticle]: https://www.linkedin.com/pulse/what-do-domain-name-how-get-one-free-tobias-brenner?trk=public_post-content_share-article
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2024.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-production%20ready-brightgreen.svg
 [releases-shield]: https://img.shields.io/github/v/release/brenner-tobias/addon-cloudflared?include_prereleases
 [releases]: https://github.com/brenner-tobias/addon-cloudflared/releases

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -326,7 +326,7 @@ check [the contributor's page][contributors].
 
 MIT License
 
-Copyright (c) 2024 Tobias Brenner
+Copyright (c) 2025 Tobias Brenner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Proposed Changes

To be merged right after related PRs

## Related PRs

https://github.com/brenner-tobias/ha-addons-edge/pull/4
https://github.com/brenner-tobias/ha-addons/pull/29

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year to 2025 in the LICENSE.md, README.md, and DOCS.md files.
	- Updated maintenance badge URL to reflect the new year in README.md and cloudflared/.README.j2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->