### PR TITLE
Add comment on how to delete additional_hosts option

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -139,9 +139,16 @@ additional_hosts:
     disableChunkedEncoding: true
 ```
 
-**Note**: _If you delete a hostname from the list, it will not be served
+**Note 1**: _If you delete a hostname from the list, it will not be served
 anymore. Nevertheless, you should also manually delete the DNS entry from
 Cloudflare since it can not be deleted by the add-on._
+
+**Note 2**: _If you want to fully delete the additional_hosts option,
+you have to add an empty array in the configuration as follows:._
+
+```yaml
+additional_hosts: []
+```
 
 ### Option: `tunnel_name`
 


### PR DESCRIPTION
# Proposed Changes

Add comment on how to delete additional_hosts option in documentation

## Related Issues

#776 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation for Cloudflared add-on
	- Added clarification about deleting hostnames and managing `additional_hosts` configuration
	- Improved guidance on DNS entry management and configuration process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->