### PR TITLE
Restrict live log nginx location

### DIFF
--- a/cloudflared/rootfs/etc/nginx/template/nginx.conf.gtpl
+++ b/cloudflared/rootfs/etc/nginx/template/nginx.conf.gtpl
@@ -33,7 +33,7 @@ http {
             proxy_set_header X-Forwarded-Host $http_host;
         }
 
-        location ~ /api/hassio/.*/logs {
+        location ~ /api/hassio/.*/logs.*/follow {
             proxy_pass http://homeassistant:{{ .port }};
             proxy_set_header Host $http_host;
             proxy_http_version 1.1;


### PR DESCRIPTION
# Proposed Changes

as supposed by @othorp restrict the nginx location which should handle the live logs
https://github.com/brenner-tobias/addon-cloudflared/discussions/744#discussioncomment-11977794 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Nginx configuration to improve log endpoint routing, specifically for log streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->