### PR TITLE
Increase nginx proxy_read_timeout

### DIFF
--- a/cloudflared/rootfs/etc/nginx/template/nginx.conf.gtpl
+++ b/cloudflared/rootfs/etc/nginx/template/nginx.conf.gtpl
@@ -40,6 +40,7 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header X-Forwarded-Host $http_host;
+            proxy_read_timeout 1d;
             proxy_cache off;
             proxy_buffering off;
             proxy_hide_header Content-Type;


### PR DESCRIPTION
# Proposed Changes

https://github.com/brenner-tobias/addon-cloudflared/discussions/744#discussioncomment-11977794
Increase timeout to 1d to prevent HA from duplicating latest log entries.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved proxy connection timeout for API log streaming, allowing longer-running log follow operations without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->