### PR TITLE
⬆️ Update nginx to 1.26.3-r0

### DIFF
--- a/cloudflared/rootfs/build.sh
+++ b/cloudflared/rootfs/build.sh
@@ -28,7 +28,7 @@ esac
 # see https://github.com/brenner-tobias/addon-cloudflared/discussions/744
 
 # renovate: datasource=repology depName=debian_12/gnupg versioning=loose
-nginx_version="1.26.2-r4"
+nginx_version="1.26.3-r0"
 apk add --no-cache nginx="${nginx_version}"
 
 # Download the cloudflared bin


### PR DESCRIPTION
# Proposed Changes

Current edge version isn't working anymore because of outdated nginx version. 

<img width="916" alt="image" src="https://github.com/user-attachments/assets/17363306-c4eb-4742-8bd3-8751e6d4c5cb" />



## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
