### PR TITLE
Add proxy option for local managed tunnels

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -79,6 +79,7 @@ advanced config can be achieved using the remote tunnel setup.
 - [`tunnel_name`](#option-tunnel_name)
 - [`catch_all_service`](#option-catch_all_service)
 - [`nginx_proxy_manager`](#option-nginx_proxy_manager)
+- [`use_builtin_proxy`](#option-use_builtin_proxy)
 - [`post_quantum`](#option-post_quantum)
 - [`run_parameters`](#option-run_parameters)
 - [`log_level`](#option-log_level)
@@ -216,6 +217,14 @@ in Cloudflare by adding a CNAME record with `*` as name.
 
 Finally, you have to set-up your proxy hosts in Nginx Proxy Manager and forward
 them to wherever you like.
+
+### Option: `use_builtin_proxy`
+
+If enabled the connection to Home Assistant will be made through the built-in
+Nginx proxy. The Nginx was implemented as workaround for issues with live logs.
+For reference see discussion #744
+
+**Note**: _This option is enabled by default._
 
 ### Option: `post_quantum`
 

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -220,9 +220,9 @@ them to wherever you like.
 
 ### Option: `use_builtin_proxy`
 
-If enabled the connection to Home Assistant will be made through the built-in
-Nginx proxy. The Nginx was implemented as workaround for issues with live logs.
-For reference see discussion [#744](https://github.com/brenner-tobias/addon-cloudflared/discussions/744)
+If enabled, the connection to Home Assistant will be made through the built-in
+Nginx proxy. Nginx was implemented as a workaround for issues with live logs.
+For reference, see discussion [#744](https://github.com/brenner-tobias/addon-cloudflared/discussions/744)
 
 **Note**: _This option is enabled by default._
 

--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -222,7 +222,7 @@ them to wherever you like.
 
 If enabled the connection to Home Assistant will be made through the built-in
 Nginx proxy. The Nginx was implemented as workaround for issues with live logs.
-For reference see discussion #744
+For reference see discussion [#744](https://github.com/brenner-tobias/addon-cloudflared/discussions/744)
 
 **Note**: _This option is enabled by default._
 

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -29,6 +29,7 @@ schema:
   tunnel_name: str?
   catch_all_service: str?
   nginx_proxy_manager: bool?
+  use_builtin_proxy: bool?
   tunnel_token: str?
   post_quantum: bool?
   run_parameters:

--- a/cloudflared/rootfs/etc/nginx/template/nginx.conf.gtpl
+++ b/cloudflared/rootfs/etc/nginx/template/nginx.conf.gtpl
@@ -25,7 +25,12 @@ http {
         proxy_buffering off;
 
         location / {
+            {{- if not .ssl }}
             proxy_pass http://homeassistant:{{ .port }};
+            {{- else }}
+            proxy_pass https://homeassistant:{{ .port }};
+            proxy_ssl_verify        off;
+            {{- end }}
             proxy_set_header Host $http_host;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -34,7 +39,12 @@ http {
         }
 
         location ~ /api/hassio/.*/logs.*/follow {
+            {{- if not .ssl }}
             proxy_pass http://homeassistant:{{ .port }};
+            {{- else }}
+            proxy_pass https://homeassistant:{{ .port }};
+            proxy_ssl_verify        off;
+            {{- end }}
             proxy_set_header Host $http_host;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -13,14 +13,18 @@ set -e
 
 bashio::log.debug "Merging options & variables for template"
 # shellcheck disable=SC2046
-JSON_CONF=$(jq --arg port $(bashio::core.port) \
-    '({port: $port})' \
-    /data/options.json)
+JSON_CONF=$(jq -n \
+    --arg port "$(bashio::core.port)" \
+    --arg ssl "$(bashio::core.ssl)" \
+    '{port: $port, ssl: ($ssl | fromjson)}')
 bashio::log.debug "Generating nginx.conf from template in /etc/nginx/nginx.conf.gtpl"
+bashio::log.debug "JSON_CONF: ${JSON_CONF}"
 # shellcheck disable=SC2086
 echo $JSON_CONF | tempio \
     -template /etc/nginx/template/nginx.conf.gtpl \
     -out /etc/nginx.conf
+bashio::log.debug "Generated nginx.conf:"
+bashio::log.debug "$(cat /etc/nginx.conf)"
 
 # start server
 bashio::log.info "Running nginx..."

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -228,7 +228,11 @@ createConfig() {
 
     # Add Service for Home Assistant if 'external_hostname' is set
     if bashio::config.has_value 'external_hostname' ; then
-        config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"${ha_service_protocol}://homeassistant:$(bashio::core.port)\"}]")
+        if ! bashio::config.has_value 'use_builtin_proxy' or bashio::config.true 'use_builtin_proxy' ; then
+            config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"http://localhost:8321\"}]")
+        else
+            config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"${ha_service_protocol}://homeassistant:$(bashio::core.port)\"}]")
+        fi
     fi
 
     # Check for configured additional hosts and add them if existing

--- a/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/scripts/cloudflared-config.sh
@@ -228,7 +228,7 @@ createConfig() {
 
     # Add Service for Home Assistant if 'external_hostname' is set
     if bashio::config.has_value 'external_hostname' ; then
-        if ! bashio::config.has_value 'use_builtin_proxy' or bashio::config.true 'use_builtin_proxy' ; then
+        if ! bashio::config.has_value 'use_builtin_proxy' || bashio::config.true 'use_builtin_proxy' ; then
             config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"http://localhost:8321\"}]")
         else
             config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"${ha_service_protocol}://homeassistant:$(bashio::core.port)\"}]")

--- a/cloudflared/translations/de.yaml
+++ b/cloudflared/translations/de.yaml
@@ -38,6 +38,12 @@ configuration:
     name: Nginx-Proxy-Manager als Catch-All aktivieren
     description: >-
       Setzt das "Nginx-Proxy-Manager Add-on" als Catch-All-Dienst.
+  use_builtin_proxy:
+    name: Eingebauten Nginx proxy verwenden
+    description: >-
+      Die Verbindung zu Home Assistant wird über den eingebauten Nginx-Proxy
+      hergestellt. (Workaround für Probleme mit den Live Logs).
+      Diese Option ist standardmäßig aktiviert.
   tunnel_token:
     name: Cloudflare Tunnel Token
     description: >-

--- a/cloudflared/translations/en.yaml
+++ b/cloudflared/translations/en.yaml
@@ -39,6 +39,12 @@ configuration:
     description: >-
       Sets the catch-all service to the "Nginx-Proxy-Manager Community Add-Ons"
       Add-on.
+  use_builtin_proxy:
+    name: Use built-in Nginx proxy
+    description: >-
+      The connection to Home Assistant will be made through the built-in
+      Nginx proxy. (Workaround for issues with live logs).
+      This option is enabled by default.
   tunnel_token:
     name: Cloudflare Tunnel Token
     description: >-

--- a/cloudflared/translations/fr.yaml
+++ b/cloudflared/translations/fr.yaml
@@ -38,6 +38,12 @@ configuration:
     name: Activer le service Catch-All de Nginx-Proxy-Manager
     description: >-
       Définir le service Catch-All sur le module complémentaire "Nginx-Proxy-Manager Community Add-Ons".
+  use_builtin_proxy:
+    name: Utiliser le proxy Nginx intégré
+    description: >-
+      La connexion à Home Assistant sera établie via le proxy Nginx intégré.
+      (Solution de contournement pour les problèmes avec les journaux en direct).
+      Cette option est activée par défaut.
   tunnel_token:
     name: Token du tunnel Cloudflare
     description: >-

--- a/cloudflared/translations/he.yaml
+++ b/cloudflared/translations/he.yaml
@@ -36,6 +36,12 @@ configuration:
     name: הפעלת Catch-All Nginx-Proxy-Manager
     description: >-
       מגדיר את שירות catch-all להרחבה "Nginx-Proxy-Manager Community Add-ons".
+  use_builtin_proxy:
+    name: השתמש ב-Nginx proxy המובנה
+    description: >-
+      החיבור ל-Home Assistant יתבצע דרך ה-Nginx proxy המובנה.
+      (פתרון בעיות עבור בעיות עם יומני חיים).
+      אפשרות זו מופעלת כברירת מחדל.
   tunnel_token:
     name: אסימון מנהרת Cloudflare
     description: >-

--- a/cloudflared/translations/nl.yaml
+++ b/cloudflared/translations/nl.yaml
@@ -39,6 +39,12 @@ configuration:
     description: >-
       Gebruikt de "Nginx-Proxy-Manager Community Add-Ons" add-on als de
       catch-all dienst.
+  use_builtin_proxy:
+    name: Gebruik ingebouwde Nginx proxy
+    description: >-
+      De verbinding met Home Assistant wordt gemaakt via de ingebouwde
+      Nginx proxy. (Workaround voor problemen met live logs).
+      Deze optie is standaard ingeschakeld.
   tunnel_token:
     name: Cloudflare Tunnel Token
     description: >-

--- a/cloudflared/translations/pl.yaml
+++ b/cloudflared/translations/pl.yaml
@@ -39,6 +39,12 @@ configuration:
     description: >-
       Ustawia usługę catch-all na dodatek "Nginx-Proxy-Manager Community
       Add-Ons"
+  use_builtin_proxy:
+    name: Użyj wbudowanego proxy Nginx
+    description: >-
+      Połączenie z Home Assistant będzie realizowane przez wbudowane
+      proxy Nginx. (Obejście problemów z logami na żywo).
+      Ta opcja jest domyślnie włączona.
   tunnel_token:
     name: Token Tunelu Cloudflare
     description: >-


### PR DESCRIPTION
# Proposed Changes

As discussed in #767 I added a new add-on option `use_builtin_proxy`, which when enabled (default) changes the local managed tunnel service URI from `homeassistant:8123` to `localhost:8321`. 

I reused our logic to determine if HA is running with enabled SSL to change the related proxy SSL parameters.


## Related Issues

#767

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to enable or disable the use of a built-in Nginx proxy for connecting to Home Assistant, enabled by default.
  - The new option is available in multiple languages, including English, German, French, Hebrew, Dutch, and Polish.

- **Documentation**
  - Updated documentation to describe the new configuration option and its default behavior.

- **Bug Fixes**
  - Improved proxy handling to address issues related to live logs by conditionally routing connections through the built-in proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->