### PR TITLE
Fix 127.0.0.1 proxy errors

### DIFF
--- a/cloudflared/rootfs/etc/nginx/template/homeassistant.gtpl
+++ b/cloudflared/rootfs/etc/nginx/template/homeassistant.gtpl
@@ -2,6 +2,9 @@ server {
 
     listen 8321;
 
+    set_real_ip_from 127.0.0.1;
+    real_ip_header CF-Connecting-IP;
+
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 


### PR DESCRIPTION
# Proposed Changes

This should fix the lately reported 127.0.0.1 errors by passing the real client IP from Cloudflare to nginx.

## Related Issues

fixes #848 
closes #829
