### PR TITLE
Avoid waiting for Home Assistant before starting add-on

### DIFF
--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -6,6 +6,7 @@ description: "Use a Cloudflare Tunnel to remotely
   connect to Home Assistant without opening any ports"
 url: "https://github.com/brenner-tobias/addon-cloudflared/"
 codenotary: dev@brenner.tech
+startup: services
 init: false
 hassio_api: true
 hassio_role: homeassistant


### PR DESCRIPTION
# Proposed Changes

I believe it doesn't make sense to wait for Home Assistant to start before starting this add-on. Especially considering it can be used to access other services beyond just Home Assistant.

Also, in case Home Assistant fails to start, this add-on shouldn't be blocked from starting.

https://developers.home-assistant.io/docs/add-ons/configuration/#optional-configuration-options

## Related Issues

This PR is a copy of https://github.com/hassio-addons/addon-nginx-proxy-manager/pull/613, which I thought made total sense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflared addon configuration with a new startup setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->