### PR TITLE
Avoid starting NGINX proxy if user disabled it

### DIFF
--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -18,6 +18,7 @@ map:
 options:
   external_hostname: ""
   additional_hosts: []
+  use_builtin_proxy: true
 ports:
   36500/tcp: null
 schema:

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/finish
@@ -5,6 +5,11 @@
 # Take down the S6 supervision tree when NGINX fails
 # ==============================================================================
 
+# Avoid halting container if the built-in proxy was signaled as disabled
+if [[ -f /dev/shm/no_built_in_proxy ]]; then
+    exit 0
+fi
+
 readonly exit_code_service="${1}"
 readonly exit_code_signal="${2}"
 exit_code_container=$(cat /run/s6-linux-init-container-results/exitcode)

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -9,7 +9,14 @@
 # set up and run nginx
 # ==============================================================================
 
-set -e
+if bashio::config.false 'use_builtin_proxy'; then
+    bashio::log.info "Using Cloudflared without the built-in NGINX proxy"
+    # Send a signal to finish script to avoid halting container if the built-in proxy was disabled
+    touch /dev/shm/no_built_in_proxy
+    # Tell S6-Overlay not to restart this service
+    s6-svc -O .
+    return "${__BASHIO_EXIT_OK}"
+fi
 
 bashio::log.debug "Merging options & variables for template"
 JSON_CONF=$(jq -n \

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
@@ -231,7 +231,7 @@ createConfig() {
 
     # Add Service for Home Assistant if 'external_hostname' is set
     if bashio::config.has_value 'external_hostname'; then
-        if ! bashio::config.has_value 'use_builtin_proxy' || bashio::config.true 'use_builtin_proxy'; then
+        if bashio::config.true 'use_builtin_proxy'; then
             config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"http://localhost:8321\"}]")
         else
             config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"${ha_service_protocol}://homeassistant:$(bashio::core.port)\"}]")


### PR DESCRIPTION
# Proposed Changes

Avoids starting the NGINX proxy and wasting unnecessary resources if the user disabled the _Use built-in Nginx proxy_ option.

## Related Issues

This PR kind of backports a feature of #843.
