### PR TITLE
Document that http in configuration.yaml must no use !include or packages

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -327,6 +327,13 @@ http:
 might have to add another IP(range) here. Check your HA logs
 after attempting to connect to find the correct IP.**
 
+If you changed your Home Assistant port or enabled SSL in the [HTTP
+integration][http-integration] configuration, please make sure to keep such
+configuration directly in your Home Assistant's `configuration.yaml`. Using
+`!include` or [packages][homeassistant-packages] will prevent the add-on from
+being able to read your Home Assistant configuration and determining the proper
+Home Assistant URL for internal communication.
+
 Remember to restart Home Assistant when the configuration is changed.
 
 If you need assistance changing the config, please follow the
@@ -373,6 +380,8 @@ SOFTWARE.
 [addon-remote-or-local]: https://github.com/brenner-tobias/addon-cloudflared/wiki/How-tos#local-vs-remote-managed-tunnels
 [addon-wiki]: https://github.com/brenner-tobias/addon-cloudflared/wiki
 [advancedconfiguration]: https://www.home-assistant.io/getting-started/configuration/
+[http-integration]: https://www.home-assistant.io/getting-started/configuration/
+[homeassistant-packages]: https://www.home-assistant.io/getting-started/configuration/
 [cloudflare-sssa]: https://www.cloudflare.com/en-gb/terms/
 [cloudflare-run_parameter]: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/tunnel-run-parameters/
 [cloudflare-websockets]: https://developers.cloudflare.com/network/websockets/

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -9,14 +9,6 @@
 # set up and run nginx
 # ==============================================================================
 
-# ------------------------------------------------------------------------------
-# Read Home Assistant configuration
-# ------------------------------------------------------------------------------
-readHomeAssistantConfig() {
-    # https://github.com/mikefarah/yq/discussions/1906#discussioncomment-14065554
-    yq '(.. | select(tag == "!include")) |= load((filename | sub("/[^/]*$"; "/")) + .)' "${1}"
-}
-
 if bashio::config.false 'use_builtin_proxy'; then
     bashio::log.info "Using Cloudflared without the built-in NGINX proxy"
     # Send a signal to finish script to avoid halting container if the built-in proxy was disabled
@@ -30,12 +22,11 @@ bashio::log.debug "Merging options & variables for template"
 ha_config_file="/homeassistant/configuration.yaml"
 ha_port="8123"
 ha_ssl="false"
-if ha_config=$(readHomeAssistantConfig "${ha_config_file}"); then
+if yq . "${ha_config_file}" >/dev/null; then
     # https://www.home-assistant.io/integrations/http/#http-configuration-variables
-    ha_port=$(yq '.http.server_port // 8123' <<<"${ha_config}")
-    ha_ssl=$(yq '.http | has("ssl_certificate") and has("ssl_key")' <<<"${ha_config}")
+    ha_port=$(yq '.http.server_port // 8123' "${ha_config_file}")
+    ha_ssl=$(yq '.http | has("ssl_certificate") and has("ssl_key")' "${ha_config_file}")
 fi
-unset ha_config
 bashio::log.debug "ha_port: ${ha_port}"
 bashio::log.debug "ha_ssl: ${ha_ssl}"
 JSON_CONF=$(jq -n \


### PR DESCRIPTION
# Proposed Changes

I would love avoiding this, but I don't think it's worth it.

I still think the gains outweigh the drawbacks though.

## Related Issues

- https://github.com/brenner-tobias/addon-cloudflared/pull/870#issuecomment-3172850721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable detection of Home Assistant HTTP settings (port/SSL) by reading configuration directly from configuration.yaml.

- Documentation
  - Added guidance: if you change the Home Assistant port or enable SSL, keep those HTTP settings directly in configuration.yaml. Using !include or packages can prevent the add-on from determining the correct internal URL.
  - Added supporting cross-links for HTTP integration and Home Assistant packages.

- Refactor
  - Simplified configuration parsing to read from configuration.yaml, reducing complexity and improving robustness of internal URL detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->