### PR TITLE
Fix resolving Home Assistant port before it starts

### DIFF
--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
@@ -219,9 +219,11 @@ createConfig() {
 
     bashio::log.debug "Checking if SSL is used in Home Assistant..."
     local ha_config_file="/homeassistant/configuration.yaml"
+    local ha_port="8123"
     local ha_ssl="false"
     if yq . "${ha_config_file}" >/dev/null; then
         # https://www.home-assistant.io/integrations/http/#http-configuration-variables
+        ha_port=$(yq ".http.server_port // ${ha_port}" "${ha_config_file}")
         ha_ssl=$(yq '.http | (has("ssl_certificate") and has("ssl_key"))' "${ha_config_file}")
     else
         bashio::log.warning "No Home Assistant configuration file found, assuming no SSL"
@@ -237,7 +239,7 @@ createConfig() {
 
     # Add Service for Home Assistant if 'external_hostname' is set
     if bashio::config.has_value 'external_hostname'; then
-        config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"${ha_service_protocol}://homeassistant:$(bashio::core.port)\"}]")
+        config=$(bashio::jq "${config}" ".\"ingress\" += [{\"hostname\": \"${external_hostname}\", \"service\": \"${ha_service_protocol}://homeassistant:${ha_port}\"}]")
     fi
 
     # Check for configured additional hosts and add them if existing


### PR DESCRIPTION
# Proposed Changes

The Home Assistant API should not be used to retrieve the port number because the add-on may start before Home Assistant is ready.

## Related Issues

This was a miss from:

- https://github.com/brenner-tobias/addon-cloudflared/pull/870.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects external ingress URL to respect Home Assistant’s HTTP port, defaulting to 8123 and automatically detecting a custom server_port from your configuration. This resolves wrong-port links and improves connectivity for users running Home Assistant on non-default ports.
  * Ensures consistent behavior when no configuration is present by applying a safe default, reducing setup friction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->