### PR TITLE
Avoid parsing HA config if not needed (external_hostname unset)

### DIFF
--- a/cloudflared/DOCS.md
+++ b/cloudflared/DOCS.md
@@ -108,8 +108,6 @@ to use to access Home Assistant on.
 This is optional, `additional_hosts` can be used instead to only expose other
 services.
 
-**Note**: _The tunnel name needs to be unique in your Cloudflare account._
-
 ```yaml
 external_hostname: ha.example.com
 ```


### PR DESCRIPTION
# Proposed Changes

I never realized users could run the add-on without setting `external_hostname` while still setting `additional_hosts`.

In this case, the Home Assistant port and protocol is irrelevant, and therefore we can apply this little optimization.

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Skip Home Assistant port/SSL checks when no external hostname is configured, reducing unnecessary processing and potential errors.
  - Create DNS entries only when an external hostname is set; otherwise, DNS creation is skipped.
  - Added a debug log when external hostname is missing to clarify skipped steps.

- Documentation
  - Removed note stating tunnel names must be unique within the Cloudflare account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->